### PR TITLE
find-real+

### DIFF
--- a/bin/cp
+++ b/bin/cp
@@ -1,8 +1,10 @@
-# -*- sh -*-
-# shellcheck shell=bash
-# shellcheck disable=SC2230
-# shellcheck disable=SC2046 #https://github.com/koalaman/shellcheck/wiki/SC2046
-REALCP=$(find $(echo "$PATH" | tr ":" "\ ") -name cp | grep -v "$0" | head -1)
+#!/usr/bin/env bash
+
+# cp - Some additions to the traditional cp
+
+# Stash the real one, which we will need to execute at some point.
+REALCP=$(find-real cp)
+export REALCP
 
 ## DO NOT attempt to convert this to a 'getopt' implementation; it would
 ## require specifying and handling every existing option in 'cp'
@@ -18,9 +20,7 @@ while (( $# )); do
     case $arg in
         --reverse )
             opt_reverse=1
-            ## Eventually we'll remove these do_* default assignments and let
-            ## the user decide, but for now, let's always use them for these
-            ## options.
+            ## Eventually we'll remove these safety options.
             our_opts+=('-vi')
             ;;
         --tar )

--- a/bin/find-real
+++ b/bin/find-real
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# find-real
+
+# If you have your own 'foo', find the real one
+
+tempath=$PATH
+if [[ -x "$PERSONALBIN/$1" ]]; then
+    tempath=$(delpath PATH "$PERSONALBIN"; echo "$PATH")
+fi
+PATH=$tempath; hash -r; type -P $1

--- a/bin/git-go-get
+++ b/bin/git-go-get
@@ -63,7 +63,7 @@ while true; do
             ;;
         esac
     done
-set +x
+
 filter="$1"
 
 declare tmpfile
@@ -100,7 +100,6 @@ else
         cmd-echo -- 'Options --(with|no)-pr not yet implemented'
     fi
 
-    set +x
 fi
 
 if [[ -n "$filter" ]]; then

--- a/bin/git.env
+++ b/bin/git.env
@@ -11,11 +11,7 @@
 ## our git wrapper will be found and our git wrapper needs REALGIT - circular
 ## reference.
 ##
-tempath=$PATH
-if [[ -x "$PERSONALBIN/git" ]]; then
-    tempath=$(delpath PATH "$PERSONALBIN"; echo "$PATH")
-fi
-REALGIT=$(PATH=$tempath; hash -r; type -P git)
+REALGIT=$(find-real git)
 export REALGIT
 
 ##


### PR DESCRIPTION
bin/cp
* Use find-real to get the real 'cp' command. The previous hardcoded algo
  used 'find' which had issues with non-existent PATHs and unpermitted
  paths due to the Windows directories added to PATH under WSL.

bin/find-real
* First commit.

bin/git-go-get
* Remove multiple spurious set +x calls.

bin/git.env
* Use find-real to get the real git command.