### PR TITLE
Updates on worf359

### DIFF
--- a/README-direct.md
+++ b/README-direct.md
@@ -5,6 +5,25 @@ GitHub.
 
 # Setup
 
+## ssh
+Make a `${HOME}/.ssh` directory if it does not already exist. Set it `chmod 700`. Copy your `id_rsa` and `id_rsa.pub` files into the directory and set them `chmod 401`
+
+## git
+Execute the following to install the latest version of git:
+```
+sudo add-apt-repository ppa:git-core/ppa
+sudo apt update
+apt list --upgradable
+sudo apt upgrade
+```
+
+## Local Software
+We put stuff that we build in /opt/mop:
+```
+sudo mkdir -p /opt/mop/build
+sudo chown -R /opt
+```
+
 ## Grab the repos
 
 There are two - one for git templates and the personal repo with all the code.
@@ -55,15 +74,16 @@ Either way, we will refer to this branch as `machine-branch` later on.
 
 ## Set up dotfiles
 
-This step stores existing dotfiles and links to new ones in the repo.
+This step stores existing dotfiles and links to new ones in the repo. The log file is so that you can have a record od what fails so that you can go back and correct it.
 
 ```
 cd $HOME/personal/dotfiles
 . ./dotfilesbootstrap
 cd ..
-bin/makesymlinks -i dotfiles
+bin/makesymlinks -i dotfiles 2>&1 | tee bin/makesymlinks.log
 export REALGIT=$(which git)
 bin/github.env.init
+git-kv --cat
 ```
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # README
+
 All my UNIX goodies including dotfiles so I can put them on any machine.
 
 ## Initial Setup
+
 There are two items to read:
 
 * If you simply want to sync your local environment with the GitHub repo
@@ -20,7 +22,7 @@ loaded:
 --- loaded alarm
 --- loaded apush
 --- loaded aunshift
---- loaded autoloaded_personal
+--- loaded autoloaded-personal
 --- loaded cdplus
 --- loaded ecd
 --- loaded editor_opt
@@ -46,7 +48,7 @@ separate line in the file `$HOME/.config/autoload-unshim.config`.
 
 Once you see no more such items, you can shut off the messages during profile
 loading by setting and exporting `AUTOLOAD_TRACK` in
-`$HOME/.config/autoload-config.dat`, which is read by `autoload` when it is
+`$HOME/.config/autotrack.config`, which is read by `autoload` when it is
 sourced in a profile. Set `AUTOLOAD_TRACK` to one of the following values:
 
 * all - Track every function load.
@@ -57,6 +59,17 @@ sourced in a profile. Set `AUTOLOAD_TRACK` to one of the following values:
 
 The default, if `$HOME/.config/autoload-config.dat` is not found, is `all`, so
 that in a new environment, you can see what's happening.
+
+### Perl modules
+
+Many of the utilities in this repo either use Perl or are Perl. Make sure these
+modules are installed:
+
+* File::Slurp
+* Lingua::EN::Inflect
+* Term::ReadLine::Gnu
+* Tk
+* Devel::ptkdb
 
 ### rsync-backups
 

--- a/bin/process-source-ctrl-log
+++ b/bin/process-source-ctrl-log
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-#debug: #!/opt/bb/bin/perl -d:ptkdb \n## < G C S > ## no-ptkdb-issue
+#debug: #!/explicit/path/to/perl -d:ptkdb \n## < G C S > ## no-ptkdb-issue
 
 use strict;
 use warnings;
@@ -464,14 +464,14 @@ sub format_scl {
           qx(git -c color.diff=$opt{color} @diffargs $opt{cached});
         my $entry;
         for my $line (@diff_text) {
-            if ( $line =~ m/^diff --git a/ ) {
+            if ( $line =~ m/^.{0,4}diff --git a/ ) {
                 $entry = $line;
                 $entry =~ s|.*b/||;
-                $entry =~ s|([/a-zA-Z0-9_.-]+).*|$1|;
+                $entry =~ s|([/a-zA-Z0-9_.+-]+).*|$1|;
                 $entry = file_git_rel_to_abs($entry);
-                $diffs{$entry} = [];
+                $diffs{"$entry"} = [];
             }
-            push @{ $diffs{$entry} }, $line;
+            push @{ $diffs{"$entry"} }, $line;
         }
     }
 
@@ -819,9 +819,9 @@ sub push_scl_to_output {
     }
 
     ## Diffs here
-    if ( $diffs{$filespec} ) {
+    if ( $diffs{"$filespec"} ) {
         push @{ $args{output} },
-          ( map { $args{format_over} . $_ } @{ $diffs{$filespec} } ), '';
+          ( map { $args{format_over} . $_ } @{ $diffs{"$filespec"} } ), '';
         $ok_to_edit = 1;
     }
 

--- a/bin/xo
+++ b/bin/xo
@@ -14,6 +14,10 @@ use on_exit
 debug=0
 forceX=0
 emacs_exe=$(type -P emacs)
+if [[ -z $emacs_exe ]] ; then
+    echo "No emacs executable found. Bye!"
+    exit 1
+fi
 emacsclient_exe="${emacs_exe}client"
 declare -a git_is_mod ## These are modified files in a git repo
 declare -a which ## We used to use the 'which' utility to find these

--- a/dotfiles/dotfilesbootstrap
+++ b/dotfiles/dotfilesbootstrap
@@ -7,6 +7,7 @@ personaldir="$(dirname "$dotdir")"
 
 declare -a funclist
 funclist=()
+funclist+=(autotrack)        # Used by everything
 funclist+=(safe_func_export) # Directly used here
 
 # Directly used in makesymlink

--- a/functions/autoloaded-personal
+++ b/functions/autoloaded-personal
@@ -11,4 +11,4 @@ autoloaded-personal ()
     echo 'personal functions are autoloaded'
     return 1
 }
-autotrack autoloaded_personal "$0"
+autotrack autoloaded-personal "$0"

--- a/functions/cd+
+++ b/functions/cd+
@@ -10,4 +10,4 @@ cd+ ()
 {
     dirlist "$@"
 }
-autotrack cdplus "$0"
+autotrack cd+ "$0"

--- a/functions/git-stash-get-count
+++ b/functions/git-stash-get-count
@@ -18,4 +18,4 @@ git-stash-get-count ()
         echo "${pre}${c}${post}"
     fi
 }
-autotrack git_stash_get_count "$0"
+autotrack git-stash-get-count "$0"

--- a/functions/github-clone
+++ b/functions/github-clone
@@ -12,4 +12,4 @@ github-clone ()
 {
     gitremote-clone github "$@"
 }
-autotrack github_clone "$0"
+autotrack github-clone "$0"

--- a/functions/github-forknclone
+++ b/functions/github-forknclone
@@ -12,4 +12,4 @@ github-forknclone ()
 {
     gitremote-forknclone github "$@"
 }
-autotrack github_forknclone "$0"
+autotrack github-forknclone "$0"

--- a/functions/perl-add-local
+++ b/functions/perl-add-local
@@ -12,4 +12,4 @@ perl-add-local()
     [[ "$1" == '-q' ]] && quiet='-d'
     perl-add-root $quiet "${TILDAE:-$HOME}/local"
 }
-autotrack perl_add_local "$0"
+autotrack perl-add-local "$0"

--- a/functions/perl-add-root
+++ b/functions/perl-add-root
@@ -48,7 +48,7 @@ perl-add-root ()
         addpath -x -f -p "$envvar" "$value"
     done
 }
-autotrack perl_add_root "$0"
+autotrack perl-add-root "$0"
 :<<'__PODUSAGE__'
 =head1 NAME
 

--- a/functions/perl-del-local
+++ b/functions/perl-del-local
@@ -10,4 +10,4 @@ perl-del-local()
 {
     perl-del-root "${TILDAE:-$HOME}/perl"
 }
-autotrack perl_del_local "$0"
+autotrack perl-del-local "$0"

--- a/functions/perl-del-root
+++ b/functions/perl-del-root
@@ -16,4 +16,4 @@ perl-del-root()
     delpath -x -c -p PATH     "$roottodel/bin"
     delpath -x -c -p MANPATH  "$roottodel/man"
 }
-autotrack perl_del_root "$0"
+autotrack perl-del-root "$0"

--- a/functions/set-browser
+++ b/functions/set-browser
@@ -30,4 +30,4 @@ set-browser ()
         fi
     fi
 }
-autotrack set_browser "$0"
+autotrack set-browser "$0"

--- a/functions/shopt+
+++ b/functions/shopt+
@@ -93,7 +93,7 @@ shopt+ ()
     shopt -q "$option" ## -q for silent; we just want the return value
     return $?
 }
-autotrack shoptplus "$0"
+autotrack shopt+ "$0"
 :<<'__PODUSAGE__'
 =head1 NAME
 

--- a/functions/switch-ps1
+++ b/functions/switch-ps1
@@ -33,7 +33,7 @@ switch-ps1 () {
 alias swap-ps1='switch-ps1 '
 alias ps1-swap='switch-ps1 '
 alias ps1-switch='switch-ps1 '
-autotrack switch_ps1 "$0"
+autotrack switch-ps1 "$0"
 :<<'__PODUSAGE__'
 =head1 NAME
 


### PR DESCRIPTION
README-direct.md
* Updates after initing worf359.

README.md
* Updates after initing worf359.

bin/process-source-ctrl-log
* Generalize shebang and debug command.

format_scl():
  * Account for color chars at diff entry start. Wasn't needed before this
    git 2.30.4.
  * Plus can be a legit char in a file name.

bin/xo
* Bail if no emacs is found.

dotfiles/dotfilesbootstrap
* Add autotrack before every other function load because it is used by
  every other function.

functions/autoloaded-personal
* autotrack arg was not script name.

functions/cd+
* autotrack arg was not script name.

functions/git-stash-get-count
* autotrack arg was not script name.

functions/github-clone
* autotrack arg was not script name.

functions/github-forknclone
* autotrack arg was not script name.

functions/perl-add-local
* autotrack arg was not script name.

functions/perl-add-root
* autotrack arg was not script name.

functions/perl-del-local
* autotrack arg was not script name.

functions/perl-del-root
* autotrack arg was not script name.

functions/set-browser
* autotrack arg was not script name.

functions/shopt+
* autotrack arg was not script name.

functions/switch-ps1
* autotrack arg was not script name.