### PR TITLE
KTLOs from home PC - 2022/08/25

### DIFF
--- a/bin/pssearch
+++ b/bin/pssearch
@@ -25,7 +25,8 @@ our %opt = (
     rtime    => 0,
     filter   => 0,
     quiet    => 0,
-    older    => 0
+    older    => 0,
+    forest   => 1
 );
 
 my %elapsed_fmt = (
@@ -53,6 +54,7 @@ GetOptions(
       color!
       filter
       quiet!
+      forest!
 
       head!
       this!
@@ -315,7 +317,8 @@ my %std_head_map =
   keys %map;
 
 ## $ENV{OS_O}=Linux is default
-my $ps = "ps --forest -o $fmtcols $opt{user}";
+my $forest = $opt{forest} ? '--forest' : '';
+my $ps     = "ps $forest -o $fmtcols $opt{user}";
 for ( $ENV{OS_O} || '' ) {
     /SunOS/ && do {
         $ps = "ps -o $fmtcols $opt{user}";
@@ -727,6 +730,11 @@ Print the 'ps' command used before the ps output.
 
 *After* applying all of the filters above, print only those items that started
  more than 'f' days ago where 'f' is a decimal; .5 is 12 hours.
+
+=item --noforest
+
+Do not display commands indented and branched. Use this if a process is forking
+in a runaway manner and the indentation goes off screen to the right.
 
 =back
 

--- a/bin/python.env
+++ b/bin/python.env
@@ -131,6 +131,8 @@ else
         echo 'python -m pylint "$@"' > "$pylint"
         chmod a+x "$pylint"
     fi
+
+    echo "$latest_available_version" > "$wanted_python_version_file"
 fi
 
 [[ -r $pypath ]] && addpath -fx PATH "$pypath"

--- a/functions/bash-history-index
+++ b/functions/bash-history-index
@@ -19,7 +19,7 @@ bash-history-index ()
     local -a files=("$@")
     local argcount="${#files[@]}"
     local verbose=1
-    ((argcount == '0')) && files=("$HISTFILE") && argcount=1 && verbose=0
+    ((argcount == 0)) && files=("$HISTFILE") && argcount=1 && verbose=0
     local i
     for i in "${files[@]}"; do
         if ((verbose==1)); then


### PR DESCRIPTION
bin/pssearch
* Added --noforest.

bin/python.env
* Forgot to save the upgraded version to the file.

functions/bash-history-index
* Remove string comp in a math expression. Why has this not failed
  before?