### PR TITLE
KTLO - 2026-06-10 10:00:00

### DIFF
--- a/bin/RXCmd
+++ b/bin/RXCmd
@@ -32,7 +32,7 @@ if [[ -z "${XARGS[2]}" ]] && [[ -n "$XTERMGEO" ]]; then
 fi
 
 if [[ -z $XTERM ]]; then
-    XTERM=$(which xterm)
+    XTERM=$(find-an-xterm)
     if [[ -z $XTERM ]]; then
         echo ">>> [RXCmd] ERROR: \$XTERM not defined and no 'xterm' found on PATH" >&2
         false; exit

--- a/bin/current-shell
+++ b/bin/current-shell
@@ -1,0 +1,6 @@
+# -*- sh -*-
+# shellcheck shell=bash
+
+# current-shell
+
+printf 'shell=%s version=%s\n' "$(ps -p $$ -h -o command)" "${BASH_VERSION:-${ZSH_VERSION:-${FISH_VERSION:-${KSH_VERSION:-unknown}}}}"

--- a/bin/find-an-xterm
+++ b/bin/find-an-xterm
@@ -1,0 +1,19 @@
+# -*- sh -*-
+# shellcheck shell=ksh
+
+# find-an-xterm
+
+if [[ -n "$XTERM" ]] ;then
+    echo "$XTERM"
+else
+    declare i
+    for i in /usr/bin/X11 /usr/bin /bin $HOME/EMPOPTGLOBALROOT/bin; do
+        declare j
+        for j in uxterm xterm; do
+            if [[ -e "$i/$j" ]]; then
+                echo "$i/$j"
+                exit
+            fi
+        done
+    done
+fi

--- a/bin/git-pre-commit-hook
+++ b/bin/git-pre-commit-hook
@@ -546,21 +546,7 @@ for (@ARGV){
                     declare remediation
                     declare checkcmd
                     declare runcheck=0
-                    if [[ -e "$G_gitroot/t/bin/apply-compile-check-everywhere" ]]; then
-                        cartonexec=''
-                        if [[ -e "$G_gitroot/runtests.local" ]]; then
-                            pre_commit_ok_echo "Sourcing $G_gitroot/runtests.local for perl compile tests."
-                            # shellcheck disable=SC1090 #https://github.com/koalaman/shellcheck/wiki/SC1090
-                            . "/$G_gitroot/runtests.local"
-                            if [[ "$RUNTESTS_USE_CARTON" = '1' ]]; then
-                                cartonexec='carton exec'
-                            fi
-                        fi
-                        checkcmd="$cartonexec $G_gitroot/t/bin/apply-compile-check-everywhere"
-                        $checkcmd "${G_perlfiles[@]}" 1>"$G_tfile" 2>&1
-                        runcheck=1
-                        remediation="To review, run: (cd $(pwd); $checkcmd ${G_perlfiles[*]})"
-                    elif [[ -e "${HOME}/personal/bin/perlcheck-bulk" ]]; then
+                    if [[ -e "${HOME}/personal/bin/perlcheck-bulk" ]]; then
                         declare -a libs
                         readarray                -t libs < <(find "$G_gitroot" -type d -name lib  -printf '-I\n%p\n')
                         readarray -O ${#libs[@]} -t libs < <(find "$G_gitroot" -type d -name perl -printf '-I\n%p\n')
@@ -577,7 +563,7 @@ for (@ARGV){
                         ((opt_verbose)) && pre_commit_ok_echo "Skipping Perl compile check, no perl compile check helpers found."
                     fi
                     ((runcheck==1)) && check "$G_tfile" \
-                                             "One or more Perl files contain syntax errors. Please review." \
+                                             "One or more Perl files contain syntax errors according to 'perl -c'. Please review." \
                                              "" \
                                              "$remediation"
                 fi
@@ -844,7 +830,7 @@ For situations where the <GCS> marker appears but you want to commit it anyway
 section where we process the marker. Extensive comments there should explain
 how to get around the issue.
 
-=item o t/bin/apply-[compile-check|perltidy]-everywhere
+=item o ~/personal/bin/perl[check|tidy]-bulk
 
 If these files are found, we run them in case they were not run during
 testing. If they fail, the commit is aborted. Skippable with --skip perl (for

--- a/bin/newx
+++ b/bin/newx
@@ -122,7 +122,7 @@ if [[ -n $XTERMFONT_SIZE ]]; then
     cmd+=('-fs' "$XTERMFONT_SIZE")
 fi
 # shellcheck disable=SC2155 #https://github.com/koalaman/shellcheck/wiki/SC2155
-export XTERM=$(which xterm)
+export XTERM=$(find-an-xterm)
 case $opt_proc_handling in
     da ) exec "${cmd[@]}" ;;
     bg ) "${cmd[@]}" &

--- a/bin/perl.mopenv
+++ b/bin/perl.mopenv
@@ -5,9 +5,10 @@ if [[ -d /home/matthew/personal/lib/perl ]]; then
     addpath -f -x -p PERL5LIB /home/matthew/personal/lib/perl
 fi
 
-if [[ -f /opt/mop/etc/bashrc ]]; then
-    . /opt/mop/etc/bashrc
+if [[ -f /opt/mop/perlbrew/etc/bashrc ]]; then
+    . /opt/mop/perlbrew/etc/bashrc
 fi
+
 
 PERLENV_LOADED=1
 export PERLENV_LOADED

--- a/bin/perlx
+++ b/bin/perlx
@@ -12,7 +12,7 @@ countem=$1; ## Specify as -x, like an option or x, like an arg
 while ((countem>0)); do
     # shellcheck disable=SC2016 #https://github.com/koalaman/shellcheck/wiki/SC2016
     # Yes, we know we are using non-expanding single quotes
-    xterm -e sh -c 'echo This terminal was started to receive a forked perl debugger process.;
+    "$TERM" -e sh -c 'echo This terminal was started to receive a forked perl debugger process.;
 echo Set;
 echo \$DB::fork_TTY=q\($(tty)\);
 echo in the debugger before you reach the fork.;

--- a/bin/post-any-install
+++ b/bin/post-any-install
@@ -13,30 +13,34 @@ declare pai_opt_os=''
 declare pai_workspace=''
 
 declare -a pai_perl_installations=(
-    perl-5.40.4
     perl-5.42.2
 )
 
-declare -a pai_system_perl_modules=(
-    App::pmuninstall
-    Email::Sender
-    Email::Simple
-    File::Slurp
-    Lingua::EN::Inflect
-    List::MoreUtils
-    Path::Tiny
-    Rand::Urandom
-    Term::Menus
+declare -A pai_system_perl_modules=(
+    ['libemail-sender-perl']='debian'
+    ['libemail-simple-perl']='debian'
+    ['libfile-slurp-perl']='debian'
+    ['liblingua-en-inflect-perl']='debian'
+    ['libjson-xs-perl']='debian'
+    ['liblocale-gettext-perl']='debian'
+    ['perl-doc']='debian'
+    ['perltidy']='debian'
+    ['liblist-moreutils-perl']='debian'
+    ['liblist-moreutils-xs-perl']='debian'
+    ['libfile-path-tiny-perl']='debian'
+    ['perl-tk']='debian'
+    ['libdevel-ptkdb-perl']='debian'
+    ['libcpan-perl-releases-perl']='debian'
+
+    ['Rand__Urandom']='cpan'
+    ['Term__Menus']='cpan'
 )
 
 # Anything in non alphabetical order is a prereq of something else.
 declare -a pai_perl_modules=(
-
-
-    #App::cpanminus
-    #App::FatPacker
+    App::cpanminus
+    App::FatPacker
     App::ModuleBuildTiny
-    App::Perlbrew
     App::pmuninstall
     Class::Tiny
     CPAN::Meta
@@ -47,7 +51,6 @@ declare -a pai_perl_modules=(
     DateTime
     Devel::PatchPerl
     Devel::PL_origargv
-    Devel::ptkdb
     Email::Sender
     Email::Simple
     Fcntl
@@ -90,10 +93,10 @@ declare -a pai_perl_modules=(
     Test::Perl::Critic
     Test::Pod
     Test::Pod::Coverage
-    Test::Tk
     Text::Levenshtein
     Text::Wrap
-    Tk
+    # skipping Tk - 800.036 fails to build. Build the patched version in ~/gits/github/matthewpersico/perl-tk/wt/fix-rt-154121
+    Test::Tk
     Tk::Balloon
     Tk::Dialog
     Tk::HList
@@ -103,6 +106,7 @@ declare -a pai_perl_modules=(
     Tk::ROText
     Tk::Table
     Tk::TextUndo
+    Devel::ptkdb
 )
 
 declare -a pai_debian_packages=(
@@ -141,6 +145,16 @@ declare -a pai_debian_packages=(
     csh
     libssl-dev
     libssl-doc
+    nedit
+    clangd
+    cmake
+)
+
+declare -a pai_homebrew_packages=(
+    gcc
+    uv
+    bashdb
+    claude-code
 )
 
 pai-ce () {
@@ -185,9 +199,6 @@ pai-get-workspace () {
 ##
 pai-add-dpkg-repos () {
     pai-ce 'Add dpkg repos'
-
-    ## Git
-    sudo apt-add-repository ppa:git-core/ppa
 
     ## Brave browser
     sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
@@ -313,32 +324,53 @@ pai-homebrew () {
     pai-ce 'Install homebrew and its packages'
     declare return_to
     return_to=$(pwd);
+
     pai-get-workspace
+
     curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > ./homebrew_install.sh || { false; exit; }
     chmod +x ./homebrew_install.sh
     declare logfile
     logfile="homebrew_install.$(date +%Y-%m-%dT%H-%M-%S).log"
-    echo "*** $(date)" > "$logfile"
-    ./homebrew_install.sh | tee -a "$logfile"
+    pai-ce "Logfile is $logfile"
+    (
+        echo "*** $(date)"
+        ./homebrew_install.sh
+    ) 2>&1 | tee "$logfile"
+    pai-ce "Logfile is $logfile"
+    cd "$return_to" || { false; exit; }
+}
 
+pai-homebrew-packages () {
+    api-cd - "Install homebrew packages"
     if [[ ! -f $HOME/personal/bin/homebrew.mopenv ]]; then
         pai-ce -ec "Environment file $HOME/personal/bin/homebrew.mopenv not found. No homebrew package installations will take place."
     else
         . "$HOME"/personal/bin/homebrew.mopenv
-        declare -a homebrew_packages=(
-            gcc
-            uv
-            bashdb
-        )
 
-        declare homebrew_package
-        for homebrew_package in "${homebrew_packages[@]}"; do
-            echo
-            pai-ce "$homebrew_package..."
-            brew install "$homebrew_package"
-        done
+        declare return_to
+        return_to=$(pwd)
+
+        pai-get-workspace
+
+        declare logfile
+        logfile="$(pwd)/perlbrew_install.$(date +%Y-%m-%dT%H-%M-%S).log"
+        pai-ce "Logfile is $logfile"
+        (
+            # Install
+            declare homebrew_package
+            declare homebrew_package_count="${#pai_homebrew_packages[@]}"
+            declare homebrew_package_idx=0
+            for homebrew_package in "${pai_homebrew_packages[@]}"; do
+                echo
+                ((homebrew_package_idx+=1))
+                pai-ce "*********** $homebrew_package... ($homebrew_package_idx/$homebrew_package_count)  $(date)"
+                brew install "$homebrew_package"
+            done
+        ) 2>&1 | tee "$logfile"
     fi
-    cd "$return_to" || exit
+
+    pai-ce "Logfile is $logfile"
+    cd "$return_to" || { false; exit; }
 }
 
 ##
@@ -353,13 +385,13 @@ _pai-perlbrew-make-alias-name () {
 }
 
 pai-perlbrew () {
-    pai-ce 'Install perlbrew and perl insallations'
+    pai-ce 'Install perlbrew and perl installations'
     declare return_to
     return_to=$(pwd);
 
     pai-get-workspace
 
-    export PERLBREW_ROOT=/opt/mop
+    export PERLBREW_ROOT=/opt/mop/perlbrew
     curl -L https://install.perlbrew.pl > ./perlbrew_install.sh || { false; exit; }
     chmod +x ./perlbrew_install.sh
 
@@ -370,36 +402,43 @@ pai-perlbrew () {
         echo "*** $(date)"
         ./perlbrew_install.sh
 
-        if ! grep /opt/mop/etc/bashrc "$HOME/personal/bin/perl.mopenv" ; then
-            pai-ce "Adding '/opt/mop/etc/bashrc' to '$HOME/personal/bin/perl.mopenv'..."
+        declare perlbrew_rc=$PERLBREW_ROOT/etc/bashrc
+        if ! grep $perlbrew_rc "$HOME/personal/bin/perl.mopenv" ; then
+            pai-ce "Adding '$perlbrew_rc' to '$HOME/personal/bin/perl.mopenv'..."
             cat << EOF >> "$HOME/personal/bin/perl.mopenv"
 
-if [[ -f /opt/mop/etc/bashrc ]]; then
-    . /opt/mop/etc/bashrc
+if [[ -f $perlbrew_rc ]]; then
+    . $perlbrew_rc
 fi
 
 EOF
         else
-            pai-ce "'/opt/mop/etc/bashrc' already in '$HOME/personal/bin/perl.mopenv'..."
+            pai-ce "'$perlbrew_rc' already in '$HOME/personal/bin/perl.mopenv'..."
         fi
 
-        source /opt/mop/etc/bashrc
+        # shellcheck disable=SC1090 #https://github.com/koalaman/shellcheck/wiki/SC1090
+        source "$perlbrew_rc"
         perlbrew install-patchperl
 
         # List of perl versions we care about
-        declare perl_installations
+        declare -a perl_installations_to_install
         if [[ -n $1 ]]; then
-            ajoin perl_installations -s , "$@"
+            perl_installations_to_install=("$@")
         else
-            ajoin perl_installations -s , "${pai_perl_installations[@]}"
+            perl_installations_to_install=("${pai_perl_installations[@]}")
         fi
-        pai-ce "Installing $perl_installations"
+
+        declare perl_installations_list
+        ajoin perl_installations_list -s , "{perl_installations_to_install[@]}"
+        pai-ce "Installing $perl_installations_list"
 
         declare perl_installation
-        for perl_installation in "${perl_installations[@]}"; do
+        for perl_installation in "${perl_installations_to_install[@]}"; do
             if perlbrew install "$perl_installation"; then
+
+                # Alias
                 declare perl_installation_alias
-                perl_installation_alias=$(_pai_perlbrew-make-alias-name "$perl_installation")
+                perl_installation_alias=$(_pai-perlbrew-make-alias-name "$perl_installation")
                 if perlbrew alias create "$perl_installation" "$perl_installation_alias" 2>&1 | grep -q 'already exists'; then
                     declare existing_alias_value
                     existing_alias_value=$(perlbrew exec --with "$perl_installation_alias" perl -e '$v=$^V;$v=~s/v/perl-/;print $v')
@@ -409,6 +448,10 @@ EOF
                 else
                     pai-ce "Created $perl_installation_alias as an alias for $perl_installation"
                 fi
+
+                # Locally built modules
+                # - TK
+                echo "cd ~/gits/github/matthewpersico/perl-tk/wt/fix-rt-154121; perl Makefile.PL; make install"
             fi
         done
     ) 2>&1 | tee "$logfile"
@@ -421,8 +464,8 @@ pai-perlbrew-modules () {
 
     # shellcheck disable=SC2031 #https://github.com/koalaman/shellcheck/wiki/SC2031
     if [[ -z $PERLBREW_ROOT ]]; then
-        pai-ce 'perlbrew not initialized in this shell. Will source "/opt/mop/etc/bashrc".'
-        source /opt/mop/etc/bashrc
+        pai-ce "perlbrew not initialized in this shell. Will source \"$PERLBREW_ROOT/etc/bashrc\"."
+        source $PERLBREW_ROOT/etc/bashrc
     fi
 
     declare return_to
@@ -448,9 +491,12 @@ pai-perlbrew-modules () {
 
         # Install
         declare perl_module
+        declare perl_module_count="${#pai_perl_modules[@]}"
+        declare perl_module_idx=0
         for perl_module in "${pai_perl_modules[@]}"; do
             echo
-            pai-ce "*********** $perl_module..."
+            ((perl_module_idx+=1))
+            pai-ce "*********** $perl_module... ($perl_module_idx/$perl_module_count)  $(date)"
             perlbrew exec --with "$perl_installations" cpanm "$perl_module"
         done
     ) 2>&1 | tee "$logfile"
@@ -460,10 +506,9 @@ pai-perlbrew-modules () {
 
 pai-system-perl-modules () {
     ##
-    ## Install perl modules to get later versions of OS packaged Perl modules
-    ## we used to bootstrap and other needed packages.
+    ## Install perl modules from the debian packages first, CPAN if there is no debian package.
     ##
-    pai-ce 'Install Perl modules from cpan for the system Perl'
+    pai-ce 'Install Perl modules as debian packages, CPAN only if necessary.'
 
     declare perlbrew_return="$PERLBREW_PERL"
     if [[ -n "$perlbrew_return" ]]; then
@@ -471,19 +516,30 @@ pai-system-perl-modules () {
     fi
 
     # Bootstrap cpan
-    pai-ce "cpan boostraps"
+    pai-ce "cpan bootstraps"
     sudo cpan install CPAN
+
     pai-ce "Update cpan itself..."
     sudo cpan install Log::Log4perl Text::Levenshtein App::cpanminus
 
-    pai-ce "Now using cpanm..."
+    pai-ce "Now using the list..."
     declare perl_module
-    for perl_module in "${pai_system_perl_modules[@]}"; do
+    for perl_module in "${!pai_system_perl_modules[@]}"; do
         echo
-        pai-ce "$perl_module..."
-        sudo cpanm install "$perl_module"
+        declare sys=${pai_system_perl_modules[$perl_module]}
+        case $sys in
+            debian)
+                pai-ce "$perl_module..."
+                sudo apt install "$perl_module"
+                ;;
+            cpan)
+                declare pm="$perl_module"
+                pm="${pm//__/::}"
+                pai-ce "$pm..."
+                sudo cpanm "$pm"
+                ;;
+        esac
     done
-
     if [[ -n "$perlbrew_return" ]]; then
         perlbrew switch "$perlbrew_return"
     fi
@@ -652,6 +708,7 @@ main () {
         pai-distro-debian-packages
         pai-local-debian-packages
         pai-homebrew
+        pai-homebrew-packages
         pai-perlbrew
         pai-perlbrew-modules
         pai-build-oss
@@ -665,6 +722,7 @@ main () {
         pai-distro-debian-packages
         pai-local-debian-packages
         pai-homebrew
+        pai-homebrew-packages
         pai-perlbrew
         pai-perlbrew-modules
         pai-build-oss

--- a/bin/vterm-shell
+++ b/bin/vterm-shell
@@ -1,0 +1,1 @@
+/bin/bash -l

--- a/dotfiles/bash_profile
+++ b/dotfiles/bash_profile
@@ -8,6 +8,17 @@
 # and linters. profiles are not executed. They are sourced into the shell that
 # calls them, to which any line with a # is a comment.
 
+# How to safely switch shells: we don't change your shell in /etc/passwd. We
+# re-exec the desired shell if it exists. Otherwise, we carry on with the
+# default.
+
+if [ -x /home/linuxbrew/.linuxbrew/bin/bash ] && [ -z "$HOMEBREW_BASH_REEXEC" ]; then
+  export HOMEBREW_BASH_REEXEC=1
+  export SHELL=/home/linuxbrew/.linuxbrew/bin/bash
+  exec /home/linuxbrew/.linuxbrew/bin/bash -l
+fi
+echo "**** shell is $SHELL ****"
+
 # How to tell if we are running during profile setup or not
 RUNNING_IN_BASH_PROFILE=1
 export RUNNING_IN_BASH_PROFILE
@@ -82,13 +93,13 @@ if [[ -z "$(declare -F autoload )" ]]; then
 fi
 
 if [[ -z "$(declare -F autoloaded-personal)" ]]; then
-    declare -a _profile_autoload_args
-    _profile_autoload_args=(-x -o)
+    declare -a _profile_autoload_opts
+    _profile_autoload_opts=(-x -o)
     declare -a _profile_autoload_summary
 
     ## First, load autoload tracking, unshimmed, since every other function
     ## will use it.
-    autoload "${_profile_autoload_args[@]}" \
+    autoload "${_profile_autoload_opts[@]}" \
              "${_profile_autoload_summary[@]}" \
              -l \
              autotrack
@@ -105,7 +116,7 @@ if [[ -z "$(declare -F autoloaded-personal)" ]]; then
     declare _profile_unshim_list="${HOME}/.config/autoload-unshim.config"
     if [[ -f "$_profile_unshim_list" ]]; then
         while read -r _profile_unshim_func; do
-            autoload "${_profile_autoload_args[@]}" \
+            autoload "${_profile_autoload_opts[@]}" \
                      -l \
                      "$_profile_unshim_func"
             ((_profile_unshim_count+=1))
@@ -118,7 +129,7 @@ if [[ -z "$(declare -F autoloaded-personal)" ]]; then
     ## called, in which case its shim, or its full function code, will be
     ## ready.
     ! $CRON && _profile_autoload_summary+=(-y)
-    autoload "${_profile_autoload_args[@]}" \
+    autoload "${_profile_autoload_opts[@]}" \
              "${_profile_autoload_summary[@]}" \
              -a "$PERSONALROOT/functions"
 

--- a/dotfiles/perldb
+++ b/dotfiles/perldb
@@ -258,7 +258,7 @@ my $skip;
 my @classes;
 
 BEGIN {
-    if ( defined ($ENV{TERM}) && $ENV{TERM} =~ m/^xterm./ ) {
+    if ( not defined ($ENV{TERM}) or $ENV{TERM} ne 'xterm'./ ) {
         print STDERR <<"END";
 
 Debugger changing:

--- a/dotfiles/xterminit
+++ b/dotfiles/xterminit
@@ -21,13 +21,7 @@ if [[ -z "$DISPLAY" ]]; then
 fi
 
 if [[ -z "$XTERM" ]]; then
-    declare i
-    for i in /usr/bin/X11 /usr/bin /bin $HOME/EMPOPTGLOBALROOT/bin; do
-        if [[ -z "$XTERM" ]] && [[ -e "$i/xterm" ]]; then
-            XTERM="$i/xterm"
-            break
-        fi
-    done
+    XTERM=$(find-an-xterm)
     if [[ -z "$XTERM" ]]; then
         "$PERSONALBIN/cmd-echo" --id xterminit --info "$(date) - $(hostname) - Cannot find an xterm to use. xterm setup stops." >> ~/xterminit.stop
         true; return

--- a/functions/bash-history-init
+++ b/functions/bash-history-init
@@ -16,7 +16,11 @@ bash-history-init ()
         HISTDIR=${HOME}/.bash_histories
         export HISTDIR # Not one of the standard HIST* vars so it has not been
         # exported already
-        HISTCOLOR=$(xterm-cli background)
+        if [[ -n $INSIDE_EMACS ]]; then
+            HISTCOLOR=${INSIDE_EMACS// /:}
+        else
+            HISTCOLOR=$(xterm-cli background)
+        fi
         [[ -n $HISTCOLOR ]] && HISTCOLOR="${HISTCOLOR}."
         HISTFILE=${HISTDIR}/hist.$(hostname).${HISTCOLOR}$(date +%Y_%m_%d_%H_%M_%S).$$
         if [[ ! -d "${HOME}"/.bash_histories ]]; then

--- a/functions/git
+++ b/functions/git
@@ -280,4 +280,6 @@ to execute. Set it B<all> to catpure all commands or set it to
 to capture only those three commands. You can use any number of comma-separated
 commands.
 
+=back
+
 __PODUSAGE__


### PR DESCRIPTION
bin/RXCmd
* Allow for more than one "xterm" program.

bin/current-shell
* New - Show command line shell start command and version.

bin/find-an-xterm
* New - extracted from xterminit to be used in multiple places and expanded to multiple programs in addition to multiple locations.

bin/git-pre-commit-hook
* Strip out the last employer-specific part of the Perl checks.

bin/newx
* Allow for more than one "xterm" program

bin/perl.mopenv
* We moved perlbrew so fix the corresponding bashrc location.

bin/perlx
countem():
  * Allow for more than one "xterm".

bin/post-any-install
* Factored module/package installs for homebrew and system perl.
* Down to only perl 5.42 for perlbrew.
* Many new packages.

pai-perlbrew():
  * Tk is built locally from the rt-154121 patch.
  * Moved perlbrew install from /opt/mop to /opt/mop/perlbrew for a cleaner install.

bin/vterm-shell
* New - run this as the vterm-shell in emacs so we can control what gets run, including any args and options.

dotfiles/bash_profile
* Re-exec to use homebrew bash.

dotfiles/perldb
* xterm setup for debugging was the inverted condition.

dotfiles/xterminit
* Allow for more than one "xterm" program.

functions/bash-history-init
* Account for being in an emacs vterm.

functions/git
* Fix pod.