### PR TITLE
KTLO - 2026-06-10 11:30:00

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,15 @@ sourced in a profile. Set `AUTOLOAD_TRACK` to one of the following values:
 * all - Track every function load.
 * :cron: - Only track in cron jobs.
 * :noncron: - Only track in non-cron jobs.
+* :profile: - Only track after .profile is run.
 * :noprofile: - Only track after .profile is run.
 * none - Do not track in anything.
 
-The default, if `$HOME/.config/autoload-config.dat` is not found, is `all`, so
+The reason that there are colons around the cron and profile options is that
+they can be combined. For example, if you want tracking in crons, but not in
+login profiles, set `AUTOLOAD_TRACK` to `:cron:noprofile:`.
+
+The default, if `$HOME/.config/autotrack.config` is not found, is `all`, so
 that in a new environment, you can see what's happening.
 
 ### Perl modules

--- a/bin/autoload
+++ b/bin/autoload
@@ -642,9 +642,9 @@ NOTES
 
               export PS4="$PS4_DEFAULT"
 
-          The default PS4 prompt is a set of +, one fot each nested shell
-          level. When you want to debug with 'set -x' and you want to know
-          where the code lines are coming from:
+          The default PS4 prompt is a string of plus signs (+), one for each
+          nested shell level. When you want to debug with 'set -x' and you want
+          to know where the code lines are coming from:
 
           $ export PS4="$PS4_LONG"
 

--- a/bin/git.mopenv
+++ b/bin/git.mopenv
@@ -33,30 +33,36 @@ GITENV_REPO_ROOT=$(git config --get --expand ext.git-repo-root.root)
 export GITENV_REPO_ROOT
 [[ ! -e "$GITENV_REPO_ROOT" ]] &&  mkdir -vp "$GITENV_REPO_ROOT"
 
+declare _git_mopenv_do_echo=false
+if [[ ( $CRON && $AUTOLOAD_TRACK =~ :cron:) \
+          ||  $AUTOLOAD_TRACK =~ :profile: ]]; then
+    _git_mopenv_do_echo=true
+fi
+
 if ! declare -F | grep -q __git_ps1; then
-    ! $CRON && "$PERSONALBIN/cmd-echo" --id git.mopenv --info "__git_ps1 not loaded."
+    $_git_mopenv_do_echo && "$PERSONALBIN/cmd-echo" --id git.mopenv --info "__git_ps1 not loaded."
     declare shl
     shl="$(hash -r; "${REALGIT}" --exec-path)/git-sh-prompt"
     if [[ -e "$shl" ]]; then
         . "$shl"
         safe_func_export __git_ps1
-        ! $CRON && "$PERSONALBIN/cmd-echo" --id git.mopenv --info "$shl loaded."
+        $_git_mopenv_do_echo && "$PERSONALBIN/cmd-echo" --id git.mopenv --info "$shl loaded."
     else
-        ! $CRON && "$PERSONALBIN/cmd-echo" --id git.mopenv --warn "$shl not found."
+        $_git_mopenv_do_echo && "$PERSONALBIN/cmd-echo" --id git.mopenv --warn "$shl not found."
     fi
 fi
 
 if ! declare -F | grep -q __git_complete; then
-    ! $CRON && "$PERSONALBIN/cmd-echo" --id git.mopenv --info "__git_complete not loaded."
+    $_git_mopenv_do_echo && "$PERSONALBIN/cmd-echo" --id git.mopenv --info "__git_complete not loaded."
     declare gitinstallroot
     gitinstallroot=$(dirname "$(dirname "$REALGIT")")
     declare shl="$gitinstallroot/share/bash-completion/completions/git"
     if [[ -e "$shl" ]]; then
         . "$shl"
         safe_func_export __git_complete __git_sequencer_status __git_eread
-        ! $CRON && "$PERSONALBIN/cmd-echo" --id git.mopenv --info "$shl loaded."
+        $_git_mopenv_do_echo && "$PERSONALBIN/cmd-echo" --id git.mopenv --info "$shl loaded."
     else
-        ! $CRON && "$PERSONALBIN/cmd-echo" --id git.mopenv --warn "$shl not found."
+        $_git_mopenv_do_echo && "$PERSONALBIN/cmd-echo" --id git.mopenv --warn "$shl not found."
     fi
 fi
 

--- a/bin/python.mopenv
+++ b/bin/python.mopenv
@@ -11,9 +11,15 @@ export VIRTUAL_ENV_DISABLE_PROMPT=1
 
 declare -a ceid=('--id' 'python.mopenv')
 
+declare _python_mopenv_do_echo=false
+if [[ ( $CRON && $AUTOLOAD_TRACK =~ :cron:) \
+          ||  $AUTOLOAD_TRACK =~ :profile: ]]; then
+    _python_mopenv_do_echo=true
+fi
+
 ## Quick skip check
-if [[ -e "${HOME}/.config/skip_python" ]]; then
-    cmd-echo "${ceid[@]}" --info -- "Skipping local python by request (${HOME}/.config/skip_python exists)"
+if [[ -e "${HOME}/.config/skip-python" ]]; then
+    $_python_mopenv_do_echo && cmd-echo "${ceid[@]}" --info -- "Skipping local python by request (${HOME}/.config/skip_python exists)"
     return ## This file gets dotted in
 fi
 
@@ -107,14 +113,14 @@ else
         fi
     fi
 fi
-cmd-echo "${ceid[@]}" "${status[@]}" -- "${msg[@]}"
+$_python_mopenv_do_echo && cmd-echo "${ceid[@]}" "${status[@]}" -- "${msg[@]}"
 
 # Now let's check what "python" points to.
 which_python=$(which python)
 resolved_python=$(realpath "$which_python")
 export PYTHON_EXE=$which_python
 
-cmd-echo "${ceid[@]}" "${status[@]}" -- \
+$_python_mopenv_do_echo && cmd-echo "${ceid[@]}" "${status[@]}" -- \
          "'python' on PATH is" \
          "    $(ls -l "$which_python")" \
          "which resolves to " \

--- a/dotfiles/bash_profile
+++ b/dotfiles/bash_profile
@@ -17,7 +17,6 @@ if [ -x /home/linuxbrew/.linuxbrew/bin/bash ] && [ -z "$HOMEBREW_BASH_REEXEC" ];
   export SHELL=/home/linuxbrew/.linuxbrew/bin/bash
   exec /home/linuxbrew/.linuxbrew/bin/bash -l
 fi
-echo "**** shell is $SHELL ****"
 
 # How to tell if we are running during profile setup or not
 RUNNING_IN_BASH_PROFILE=1
@@ -121,14 +120,20 @@ if [[ -z "$(declare -F autoloaded-personal)" ]]; then
                      "$_profile_unshim_func"
             ((_profile_unshim_count+=1))
         done < "$_profile_unshim_list"
-        ! $CRON && "$PERSONALBIN/cmd-echo" --id ".profile.$USER" --info "auto-unshimmed: $_profile_unshim_count"
+        if [[ ( $CRON && $AUTOLOAD_TRACK =~ :cron:) \
+                  ||  $AUTOLOAD_TRACK =~ :profile: ]]; then
+            "$PERSONALBIN/cmd-echo" --id ".profile.$USER" --info "auto-unshimmed: $_profile_unshim_count"
+        fi
     fi
 
     ## Finally, autoload everything else. Order does not matter here since it's all
     ## shims, so nothing needs to know about anything else until it's actually
     ## called, in which case its shim, or its full function code, will be
     ## ready.
-    ! $CRON && _profile_autoload_summary+=(-y)
+    if [[ ( $CRON && $AUTOLOAD_TRACK =~ :cron:) \
+              ||  $AUTOLOAD_TRACK =~ :profile: ]]; then
+         _profile_autoload_summary+=(-y)
+    fi
     autoload "${_profile_autoload_opts[@]}" \
              "${_profile_autoload_summary[@]}" \
              -a "$PERSONALROOT/functions"

--- a/functions/autotrack
+++ b/functions/autotrack
@@ -14,7 +14,7 @@ autotrack ()
     # Default is to track if we don't find a setting. To track nothing, set to
     # 'none' in '~/.config/autotrack.config'.
     if [[ -z $AUTOLOAD_TRACK ]] \
-           ||   [[ $AUTOLOAD_TRACK == 'all' ]] \
+           ||   [[ $AUTOLOAD_TRACK =~ all ]] \
            || { [[ $AUTOLOAD_TRACK =~ :cron: ]]       && $CRON; } \
            || { [[ $AUTOLOAD_TRACK =~ :noncron: ]]    && ! $CRON; } \
            || { [[ $AUTOLOAD_TRACK =~ :profile: ]]    && [[ -n $RUNNING_IN_BASH_PROFILE ]]; } \
@@ -33,15 +33,18 @@ autotrack ()
     fi
 }
 
-## No this won't recurse; this is calling the function.
-autotrack autotrack "$0"
-
 ## We set the value for function tracking. Without any setting, all loads are
 ## tracked.
 if [[ -f "$HOME/.config/autotrack.config" ]]; then
    # shellcheck disable=SC1091 #https://github.com/koalaman/shellcheck/wiki/SC1091
    . "$HOME/.config/autotrack.config"
+   if [[ $AUTOLOAD_TRACK = 'all' ]]; then
+       export AUTOLOAD_TRACK=':cron::profile:'
+   fi
 fi
+
+## No this won't recurse; this is calling the function.
+autotrack autotrack "$0"
 
 :<<'__PODUSAGE__'
 =head1 NAME


### PR DESCRIPTION
README.md
* Corrections in relation to autotracking.

bin/autoload
* Dcc update.

bin/git.mopenv
* Use AUTOLOAD_TRACK to determine if we should echo status or not.

bin/python.mopenv
* Update verbosity from just printing to checking AUTOLOAD_TRACK.

dotfiles/bash_profile
* Update autotrack verbosity from just checking cron to checking AUTOLOAD_TRACK.

functions/autotrack
* Set AUTOLOAD_TRACK before autotracking autotrack itself so it obeys requested verbosity.

autotrack():
  * Convert AUTOLOAD_TRACK='all' to AUTOLOAD_TRACK='all:cron::profile:'. Same effect, easier to check each condition when relevant.