### PR TITLE
KTLO 2026-07-13

### DIFF
--- a/bin/build-oss
+++ b/bin/build-oss
@@ -3,144 +3,133 @@
 
 # build-oss
 declare BUILD_OSS_CONF_CODE_API_VERSION=2
-export BUILD_OSS_CONF_CODE_API_VERSION
 
-declare ceid
-ceid=$(basename "$(realpath "$0")")
-declare this
-this=$(realpath "$0")
-
-# Read the options and args from command line. Note that the long and short
-# don't have to match up.
-declare OPTSARGS
-declare shortopts=''
-declare longopts=''
-ajoin longopts -s , \
-      clean log-purge root: init pause-per-step help url:
-OPTSARGS=$(getopt -a -o "$shortopts" -l "$longopts" -n "$(basename "$0")" -- "$@")
-# Reset the command line ($@).
-eval set -- "$OPTSARGS"
-
-declare -a this_opts
-declare -a logger_opts
-declare opt_clean=0
-declare opt_root_set=0
-declare opt_root=${BUILD_OSS_ROOT:-"$OPTROOT/build/oss"}
-declare opt_init=0
-declare opt_pause_per_step=0
-declare opt_start
-
-# Reprocess the command line, extracting options and their arguments into
-# variables.
-while true; do
-    declare option=$1
-    shift
-    [[ "$option" != '--' ]] && option=${option##-} && option=${option##-}
-    case "$option" in
-        h | help )
-            bash-usage "$0"
-            true; exit
-            ;;
-        init)
-            opt_init=1
-            ;;
-        url)
-            BUILD_OSS_URL=$1;
-            shift
-            ;;
-        clean)
-            opt_clean=1
-            this_opts+=(--clean)
-            ;;
-        log-purge)
-            logger_opts+=(--purge)
-            ;;
-        root )
-            opt_root_set=1
-            opt_root=$1
-            BUILD_OSS_ROOT=$1
-            export BUILD_OSS_ROOT
-            shift
-            ;;
-        pause-per-step )
-            opt_pause_per_step=1
-            ;;
-        start-at | start )
-           opt_start=$1
-           shift
-           ;;
-        --) break ;; ## VITAL!!! Exits the while loop, no more options,
-        ## remaining $*, if any, are args
-        *)
-            cmd-echo --id logit -ec -- "$option is an invalid option."
-            false; exit ;;
-    esac
-done
-
-if ((opt_root_set)) && ((!opt_init)); then
-    cmd-echo --id "$ceid" -l $LINENO --ec "Cannot set --root without --init option."
-    false; exit
-fi
-
-if [[ -z "$BUILD_OSS_ROOT" ]]; then
-    BUILD_OSS_ROOT=$opt_root
-fi
-export BUILD_OSS_ROOT
-
-cd "$opt_root" || exit
-
-if [[ -n $1 ]]; then
-    BUILD_OSS_SOFTWARE=$1; shift
-    export BUILD_OSS_SOFTWARE
-    if [[ ! -d "$BUILD_OSS_SOFTWARE" ]]; then
-        mkdir -p "$BUILD_OSS_SOFTWARE" || exit
+build-oss-ce () {
+    local ceid='build-oss'
+    if [[ -n ${FUNCNAME[1]} ]]; then
+        ceid="$ceid (${FUNCNAME[1]})"
     fi
-    cd "$BUILD_OSS_SOFTWARE" || exit
-fi
+    cmd-echo --id="$ceid" -l "${BASH_SOURCE[1]},${BASH_LINENO[1]}" "$@"
+}
 
-if [[ -n $1 ]]; then
-    # shellcheck disable=SC2001 #https://github.com/koalaman/shellcheck/wiki/SC2001
-    BUILD_OSS_VERSION=$(echo "$1" | sed 's|/$||'); shift
-    export BUILD_OSS_VERSION
-    if [[ ! -d "$BUILD_OSS_VERSION" ]]; then
-        mkdir -p "$BUILD_OSS_VERSION" || exit
+build-oss-pause () {
+    local ceid='build-oss'
+    if [[ $1 == -f ]]; then
+        shift
+        ceid="$ceid ((${FUNCTION[1]})"
     fi
-    cd "$BUILD_OSS_VERSION" || exit
-fi
+    cmd-pause --id="$ceid"  "$@"
+}
 
-if [[ -z $BUILD_OSS_DIR ]]; then
+main () {
+    # Read the options and args from command line. Note that the long and short
+    # don't have to match up.
+    local OPTSARGS
+    local shortopts=''
+    local longopts='clean,log-purge,root:,init,pause-per-step,help,url:'
+    OPTSARGS=$(getopt -a -o "$shortopts" -l "$longopts" -n "$(basename "$0")" -- "$@")
+
+    # Reset the command line ($@).
+    eval set -- "$OPTSARGS"
+
+    local opt_clean=0
+    local opt_root_set=0
+    local opt_root=${BUILD_OSS_ROOT:-"$OPTROOT/build/oss"}
+    BUILD_OSS_ROOT="$opt_root"
+    local opt_init=0
+    local opt_pause_per_step=0
+    local opt_start
+
+    # Reprocess the command line, extracting options and their arguments into
+    # variables.
+    while true; do
+        local option=$1
+        shift
+        [[ "$option" != '--' ]] && option=${option##-} && option=${option##-}
+        case "$option" in
+            h | help )
+                bash-usage "$0"
+                true; exit
+                ;;
+            init)
+                opt_init=1
+                ;;
+            url)
+                BUILD_OSS_URL=$1;
+                shift
+                ;;
+            clean)
+                opt_clean=1
+                ;;
+            root )
+                opt_root_set=1
+                opt_root=$1
+                BUILD_OSS_ROOT=$1
+                shift
+                ;;
+            pause-per-step )
+                opt_pause_per_step=1
+                ;;
+            start-at | start )
+                opt_start=$1
+                shift
+                ;;
+            --) break ;; ## VITAL!!! Exits the while loop, no more options,
+                         ## remaining $*, if any, are args
+            *)
+                build-oss-ce --ec -- "$option is an invalid option."
+                false; exit ;;
+        esac
+    done
+
+    if ((opt_root_set)) && ((!opt_init)); then
+        build-oss-ce --ec "Cannot set --root without --init option."
+        false; exit
+    fi
+
+    cd "$BUILD_OSS_ROOT" || exit
+
+    if [[ -n $1 ]]; then
+        BUILD_OSS_SOFTWARE=$1; shift
+        if [[ ! -d "$BUILD_OSS_SOFTWARE" ]]; then
+            mkdir -p "$BUILD_OSS_SOFTWARE" || exit
+        fi
+        cd "$BUILD_OSS_SOFTWARE" || exit
+    fi
+
+    if [[ -n $1 ]]; then
+        # shellcheck disable=SC2001 #https://github.com/koalaman/shellcheck/wiki/SC2001
+        BUILD_OSS_VERSION=$(echo "$1" | sed 's|/$||'); shift
+        if [[ ! -d "$BUILD_OSS_VERSION" ]]; then
+            mkdir -p "$BUILD_OSS_VERSION" || exit
+        fi
+        cd "$BUILD_OSS_VERSION" || exit
+    fi
+
     BUILD_OSS_DIR=$(pwd)
-    export BUILD_OSS_DIR
 
-    # This is the ${software}-{$version} dir. Create by expanding the tarball.
+    # We assume we are doing the tarball source expansion method. If it's curl
+    # | sh, edit the .conf file accordingly.  This is the
+    # ${software}-{$version} dir. Typically created by expanding the tarball.
     BUILD_OSS_SOURCE_DIR="${BUILD_OSS_SOFTWARE}-${BUILD_OSS_VERSION}"
-    export BUILD_OSS_SOURCE_DIR
 
     # We leave the tar.gz off the tarball and let it be set in the config
-    BUILD_OSS_SOURCE_TARBALL_ROOT="${BUILD_OSS_SOFTWARE}-${BUILD_OSS_VERSION}"
-    export BUILD_OSS_SOURCE_TARBALL_ROOT
-
-    if [[ -n $BUILD_OSS_URL ]]; then
-        BUILD_OSS_SOURCE_TARBALL=$(basename "$BUILD_OSS_URL")
-    else
-        BUILD_OSS_SOURCE_TARBALL=${BUILD_OSS_SOURCE_TARBALL_ROOT}.tar.gz
-    fi
+    BUILD_OSS_TARBALL_ROOT="${BUILD_OSS_SOFTWARE}-${BUILD_OSS_VERSION}"
 
     if ((opt_init)); then
         if [[ -z $BUILD_OSS_SOFTWARE ]]; then
-            cmd-echo --id "$ceid" -l $LINENO --ec "Missing software name argument."
+            build-oss-ce --ec "Missing software name argument."
             false; exit
         fi
 
         if [[ -z $BUILD_OSS_VERSION ]]; then
-            cmd-echo --id "$ceid" -l $LINENO --ec "Missing software version argument."
+            build-oss-ce --ec "Missing software version argument."
             false; exit
         fi
 
-        mkdir -p "$BUILD_OSS_DIR/.logit"
-        declare conf="$BUILD_OSS_DIR/build-oss.conf"
+        local conf="$BUILD_OSS_DIR/build-oss.conf"
         if [[ -f $conf ]]; then
-            cmd-echo --id "$ceid" -l $LINENO --ec "'$conf' already exists. Will not overwrite it."
+            build-oss-ce --ec "'$conf' already exists. Will not overwrite it."
             false; exit
         fi
         cat <<EOF >"$conf"
@@ -148,149 +137,156 @@ if [[ -z $BUILD_OSS_DIR ]]; then
 # shellcheck shell=bash
 
 declare BUILD_OSS_CONF_FILE_API_VERSION=${BUILD_OSS_CONF_CODE_API_VERSION}
-export BUILD_OSS_CONF_FILE_API_VERSION
+
+# Documentation purposes:
+# BUILD_OSS_ROOT=$BUILD_OSS_ROOT
+# PWD will be \$BUILD_OSS_DIR
+BUILD_OSS_DIR=$BUILD_OSS_DIR
+BUILD_OSS_SOFTWARE=$BUILD_OSS_SOFTWARE
+BUILD_OSS_VERSION=$BUILD_OSS_VERSION
+BUILD_OSS_SOURCE_DIR=$BUILD_OSS_SOURCE_DIR
+BUILD_OSS_TARBALL_ROOT=$BUILD_OSS_TARBALL_ROOT
 
 declare tarball_ext='tar.gz' # modify as needed
-BUILD_OSS_SOURCE_TARBALL=\${BUILD_OSS_SOURCE_TARBALL_ROOT}.\$tarball_ext
-export BUILD_OSS_SOURCE_TARBALL
+BUILD_OSS_TARBALL=\${BUILD_OSS_TARBALL_ROOT}.\$tarball_ext
 
-BUILD_OSS_ROOT="${opt_root}"
-export BUILD_OSS_ROOT
+BUILD_OSS_URL="$BUILD_OSS_URL"
+
+BUILD_OSS_TIMESTAMP="\${BUILD_OSS_DIR}/build-oss.timestamp"
 
 # Enhance or remove these functions as needed.
 
 build-oss-get () {
     # Commands to get the tarball and write it to \$BUILD_OSS_DIR
     # or to get a git repo.
-    # PWD will be \$BUILD_OSS_DIR
-    # BUILD_OSS_ROOT=$BUILD_OSS_ROOT
-    # BUILD_OSS_SOFTWARE=$BUILD_OSS_SOFTWARE
-    # BUILD_OSS_VERSION=$BUILD_OSS_VERSION
-    # BUILD_OSS_DIR=$BUILD_OSS_DIR
-    # BUILD_OSS_SOURCE_DIR=$BUILD_OSS_SOURCE_DIR
-    # BUILD_OSS_SOURCE_TARBALL_ROOT=$BUILD_OSS_SOURCE_TARBALL_ROOT
-    # BUILD_OSS_SOURCE_TARBALL=$BUILD_OSS_SOURCE_TARBALL
-    curl -L $BUILD_OSS_URL -o $BUILD_OSS_SOURCE_TARBALL
+    if [[ ! -f \$BUILD_OSS_TARBALL ]]; then
+        # Pick one
+        curl -L "\$BUILD_OSS_URL" -o "\$BUILD_OSS_TARBALL"
+        # wget -O "\$BUILD_OSS_TARBALL" "\$BUILD_OSS_URL"
+    else
+        build-oss-ce "Tarball \$BUILD_OSS_TARBALL exists."
+    fi
 }
 
 build-oss-unpack () {
-    if [[ -n \$tarball_ext ]]; then
-        if ! tar zxf "\$BUILD_OSS_SOURCE_TARBALL"; then
-            false; exit;
-        fi
-    else
-        cmd-echo --id "$ceid" "No tarball. Downloaded binary."
+    if [[ -d \$BUILD_OSS_SOURCE_DIR ]]; then
+         build-oss-ce "Tarball \$BUILD_OSS_TARBALL already expanded."
+    elif ! tar -xf "\$BUILD_OSS_TARBALL"; then
+        false; exit;
     fi
 }
 
 build-oss-configure () {
-    ./configure
+    if [[ ! -r "\${BUILD_OSS_TIMESTAMP}" ]] \\
+           || find . -type f -newer "\${BUILD_OSS_TIMESTAMP}" -print -quit | grep -q . ; then
+        ./configure
+    else
+        build-oss-ce "./configure has already run"
+    fi
 }
 
 build-oss-build () {
-    make
+    if [[ ! -r "\${BUILD_OSS_TIMESTAMP}" ]] \\
+           || find . -type f -newer "\${BUILD_OSS_TIMESTAMP}" -print -quit | grep -q . ; then
+        make
+    else
+        build-oss-ce "make has already run"
+    fi
 }
 
 build-oss-test () {
-    make test
+    if [[ ! -r "\${BUILD_OSS_TIMESTAMP}" ]] \\
+           || find . -type f -newer "\${BUILD_OSS_TIMESTAMP}" -print -quit | grep -q . ; then
+	    make test
+    else
+        build-oss-ce "make test has already run"
+    fi
 }
 
 build-oss-install () {
-    make install
+    if [[ ! -r "\${BUILD_OSS_TIMESTAMP}" ]] \\
+           || find . -type f -newer "\${BUILD_OSS_TIMESTAMP}" -print -quit | grep -q . ; then
+        make install
+    else
+        build-oss-ce "make install has already run"
+    fi
 }
 
 build-oss-coda () {
-    # shellcheck disable=SC2154 #https://github.com/koalaman/shellcheck/wiki/SC2154
-    cmd-echo --id "\$ceid" "build-oss of \$BUILD_OSS_SOFTWARE version \$BUILD_OSS_VERSION is complete."
+    build-oss-ce --infoc \\
+                 "build/install of \$BUILD_OSS_SOFTWARE version \$BUILD_OSS_VERSION is complete."
+    date +%s > "\${BUILD_OSS_TIMESTAMP}"
 }
 
 EOF
-        cmd-echo --id "$ceid" -l $LINENO "$conf created. Edit if needed and re-run."
+
+        build-oss-ce "$conf created. Edit if needed and re-run."
         true; exit;
-    fi
+    else
+        cd "$BUILD_OSS_DIR" || exit
 
-    #logger_opts+=(--tee --teedir "$BUILD_OSS_DIR" --teeppid $PPID)
-    logger_opts+=(--gui)
-    logit "${logger_opts[@]}" -- "$this" "${this_opts[@]}"
-else
-    cd "$BUILD_OSS_DIR" || exit
-
-    if [[ ! -r ./build-oss.conf ]]; then
-        cmd-echo --id="$ceid" --ec "'$(pwd)/build-oss.conf' not found."
-        false; exit
-    fi
-
-    # shellcheck disable=SC1091 #https://github.com/koalaman/shellcheck/wiki/SC1091
-    . ./build-oss.conf
-
-    if [[ $BUILD_OSS_CONF_FILE_API_VERSION != "$BUILD_OSS_CONF_CODE_API_VERSION" ]]; then
-        cmd-echo --id="$ceid" --ec "build-oss.conf file api version ($BUILD_OSS_CONF_FILE_API_VERSION) does not match current version (BUILD_OSS_CONF_CODE_API_VERSION)." \
-                 "Correct and re-run."
-        false; exit
-    fi
-
-    if [[ -d $BUILD_OSS_SOURCE_DIR ]]; then
-        if ((opt_clean)); then
-            cmd-echo --id "$ceid" -l $LINENO "Cleaning $BUILD_OSS_SOURCE_DIR..."
-            rm -rf "$BUILD_OSS_SOURCE_DIR"
-        fi
-    fi
-
-    if [[ ! -e $BUILD_OSS_SOURCE_TARBALL ]]; then
-        declare full_funcname='build-oss-get'
-        if is-a-function $full_funcname; then
-            cmd-echo --id "$ceid" -l $LINENO --info "Running $full_funcname..."
-            $full_funcname || exit
-            if ((opt_pause_per_step)); then
-                cmd-pause --id "$ceid" -l $LINENO "$full_funcname complete."
-            fi
-        else
-            cmd-echo --id "$ceid" -l $LINENO -wc "No $full_funcname defined. No tarball found."
+        if [[ ! -r ./build-oss.conf ]]; then
+            build-oss-ce --ec "'$(pwd)/build-oss.conf' not found."
             false; exit
         fi
-    fi
 
-    if [[ ! -d $BUILD_OSS_SOURCE_DIR ]]; then
-        declare full_funcname='build-oss-unpack'
-        if is-a-function $full_funcname; then
-            cmd-echo --id "$ceid" -l $LINENO --info "Running $full_funcname..."
-            $full_funcname || exit
-            if ((opt_pause_per_step)); then
-                cmd-pause --id "$ceid" -l $LINENO "$full_funcname complete."
-            fi
-        else
-            cmd-echo --id "$ceid" -l $LINENO -wc "No $full_funcname defined. No expansion performed."
+        # shellcheck disable=SC1091 #https://github.com/koalaman/shellcheck/wiki/SC1091
+        . ./build-oss.conf
+
+        if [[ $BUILD_OSS_CONF_FILE_API_VERSION != "$BUILD_OSS_CONF_CODE_API_VERSION" ]]; then
+            build-oss-ce --ec "build-oss.conf file api version ($BUILD_OSS_CONF_FILE_API_VERSION) does not match current version (BUILD_OSS_CONF_CODE_API_VERSION)." \
+                         "Correct and re-run."
+            false; exit
         fi
-    else
-        cmd-echo --id "$ceid" -l $LINENO "$BUILD_OSS_SOURCE_TARBALL already expanded."
-    fi
 
-    # Now in the source dir (expansion of the tarball, if it was expanded).
-    if [[ -d "$BUILD_OSS_SOURCE_DIR" ]]; then
-        cd "$BUILD_OSS_SOURCE_DIR" || exit
-    fi
+        if [[ -d $BUILD_OSS_SOURCE_DIR ]]; then
+            if ((opt_clean)); then
+                build-oss-ce "Cleaning $BUILD_OSS_SOURCE_DIR..."
+                rm -rf "$BUILD_OSS_SOURCE_DIR"
+            fi
+        fi
 
-    declare funcname
-    for funcname in configure build test install coda; do
-        if [[ -n $opt_start ]]; then
-            if [[ $opt_start == "$funcname" ]]; then
-                opt_start=''
+        local funcname
+        local full_funcname
+        for funcname in get unpack configure build test install coda; do
+            if [[ -n $opt_start ]]; then
+                if [[ $opt_start == "$funcname" ]]; then
+                    opt_start=''
+                else
+                    build-oss-ce --wc "$funcname is not the requested start function $opt_start. Skipping."
+                    continue
+                fi
+            fi
+
+            full_funcname="build-oss-${funcname}"
+            if is-a-function $full_funcname; then
+                build-oss-ce --info "Running $full_funcname..."
+                $full_funcname || exit
+                if ((opt_pause_per_step)); then
+                    cmd-pause --id "$ceid" -l $LINENO "$full_funcname complete."
+                    echo
+                fi
             else
-                continue
+                build-oss-ce --wc "No $full_funcname defined. Skipping this step."
             fi
-        fi
-        declare full_funcname="build-oss-${funcname}"
-        if is-a-function $full_funcname; then
-            cmd-echo --id "$ceid" -l $LINENO --info "Running $full_funcname..."
-            $full_funcname || exit
-        else
-            cmd-echo --id "$ceid" -l $LINENO --wc "No $full_funcname defined. Skipping this step."
-        fi
-        if ((opt_pause_per_step)); then
-            cmd-pause --id "$ceid" -l $LINENO "$full_funcname complete."
-        fi
-    done
-fi
+
+            if [[ $funcname == 'unpack' ]]; then
+                # Now move to the source dir (expansion of the tarball, if it was
+                # expanded).
+                if [[ -d "$BUILD_OSS_SOURCE_DIR" ]]; then
+                    cd "$BUILD_OSS_SOURCE_DIR" || exit
+                else
+                    build-oss-ce --wc "BUILD_OSS_SOURCE_DIR $BUILD_OSS_SOURCE_DIR not found." \
+                                 "Post-unpack, whether we actually unpack or skip, there has to be a directory" \
+                                 "to work in in order to continue. With no directory, we must exit."
+                    false; exit
+                fi
+            fi
+        done
+    fi
+}
+
+main "$@"
 
 :<<'__PODUSAGE__'
 =head1 NAME
@@ -317,6 +313,8 @@ o A tarball named 'project-version.tar.gz' that unpacks into a subdirectory
 o A build command sequence of config, make, make test, make install
 
 then you can use this script to build it.
+
+If not, you can finagle the functions in the conf file to build it anyway.
 
 =head1 ARGUMENTS
 

--- a/bin/cmd-pause
+++ b/bin/cmd-pause
@@ -16,7 +16,7 @@ declare -a pause_args
 declare -a other_args
 while (($#)); do
     arg=$1; shift
-    if [[ $arg =~ -(w|wc|e|ec|d|dc|-)$ ]]; then
+    if [[ $arg =~ -(l|w|wc|e|ec|d|dc|-)$ ]]; then
         cmd_echo_args+=("$arg")
     elif [[ $arg =~ -(id|color) ]]; then
         cmd_echo_args+=("$arg" "$1")

--- a/bin/git-pre-commit-hook
+++ b/bin/git-pre-commit-hook
@@ -713,7 +713,7 @@ for (@ARGV){
                 if [[ -n ${skips[shellcheck]} ]]; then
                     ((opt_verbose)) && pre_commit_ok_echo "Skipping shellcheck, ${G_skip_messages[${skips[shellcheck]}]}."
                 else
-                    if ! shellcheck -x "${shellfiles[@]}" 1>"$G_tfile" 2>&1; then
+                    if ! shellcheck --source-path=SCRIPTDIR -x "${shellfiles[@]}" 1>"$G_tfile" 2>&1; then
                         # https://github.com/koalaman/shellcheck/wiki/SC2005
                         # https://github.com/koalaman/shellcheck/wiki/SC2046
                         # shellcheck disable=SC2005,SC2046

--- a/bin/inflect
+++ b/bin/inflect
@@ -1,49 +1,76 @@
 #!/usr/bin/env perl
 
 use 5.16.3;
-no strict 'refs';
+no strict 'refs';    ## no critic (TestingAndDebugging::ProhibitNoStrict)
 use warnings;
-use Lingua::EN::Inflect;
+
+use File::Basename;
+use Getopt::Long qw(GetOptionsFromArray);
+use Lingua::EN::Inflexion qw(noun verb adj inflect wordlist);
 use Pod::Usage;
 
 use MOP::Misc qw(UNIX_TRUE UNIX_FALSE);
 
 my $nl = '';
-if ( @ARGV == 0 ) {
-    pod2usage( -verbose => 2 );
+if (@ARGV == 0) {
+    pod2usage(-verbose => 2);
     exit UNIX_FALSE;
-} elsif ( $ARGV[0] eq '-h' ) {
-    pod2usage( -verbose => 2 );
+}
+elsif ($ARGV[0] eq '-h'
+    or $ARGV[0] eq '--help') {
+    pod2usage(-verbose => 2);
     exit UNIX_TRUE;
-} elsif ( $ARGV[0] eq '--pd' ) {
-    exec qw(perldoc Lingua::EN::Inflect);
-} elsif ( $ARGV[0] eq '--nl' ) {
+}
+elsif ($ARGV[0] eq '--pd') {
+    exec qw(perldoc Lingua::EN::Inflexion);
+}
+elsif ($ARGV[0] eq '--nl') {
     $nl = qq(\n);
     shift;
 }
 
-my $func = "Lingua::EN::Inflect::$ARGV[0]";
-if ( defined &{$func} ) {
-    if ( @ARGV == 1 ) {
+if (basename($0) eq 'wordlist') {
+    unshift @ARGV, 'wordlist';
+}
+my $func = "Lingua::EN::Inflexion::$ARGV[0]";
+if (defined &{$func}) {
+    if (@ARGV == 1) {
         die "Missing arguments for '$ARGV[0]'\n";
         exit UNIX_FALSE;
-    } else {
+    }
+    else {
         shift;
-        my $out = ( $func->(@ARGV) || '' );
+        my %opts;
+        if ($func =~ m/wordlist$/) {
+            GetOptions(
+                \%opts,
+                qw(
+                    conj=s
+                    sep=s
+                    oxford!
+                )
+            ) or pod2usage(-verbose => 2);
+        }
+        if (defined $opts{oxford} and not $opts{oxford}) {
+            $opts{final_sep} = '';
+        }
+        my $out = ($func->(@ARGV, (%opts ? \%opts : ())) || '');
         $out && print("${out}${nl}");
     }
-} elsif ( @ARGV == 1 ) {
-    my $out = ( Lingua::EN::Inflect::inflect(@ARGV) || '' );
+}
+elsif (@ARGV == 1) {
+    my $out = (Lingua::EN::Inflexion::inflect($ARGV[0]) || '');
     $out && print("${out}${nl}");
-} else {
-    die "Cannot make heads or tails of the arguments:[ '" . join( q(' '), @ARGV ) . "'\n";
+}
+else {
+    die "Cannot make heads or tails of the arguments:[ '" . join(q(' '), @ARGV) . "'\n";
 }
 
 __END__
 
 =head1 NAME
 
-inflect - a wrapper around Lingua::EN::Inflect
+inflect - a wrapper around Lingua::EN::Inflexion
 
 =head1 SYNOPSIS
 
@@ -55,14 +82,25 @@ inflect - a wrapper around Lingua::EN::Inflect
 
 =head1 DESCRIPTION
 
-Print the output of the requested Lingua::EN::Inflect function without a
+Print the output of the requested Lingua::EN::Inflexion function without a
 newline. Easily incorporated into shell scripts:
 
    $ declare catcount=3
-   $ echo I have $catcount $(inflect PL cat $catcount) in my house.
+   $ echo I have $(inflect '<#n:$catcount> <N: cat>') in my house.
    I have 3 cats in my house.
 
-For the list of functions and the arguments they take, see
+   $ echo I have $(inflect '<#w:$catcount> <N: cat>') in my house.
+   I have three cats in my house.
+
+   $ catcount=1
+   $ echo I have $(inflect '<#n:$catcount> <N: cat>') in my house.
+   I have 1 cat in my house.
+
+   $ catcount=0
+   $ echo I have $(inflect '<#w:$catcount> <N: cat>') in my house.
+   I have no cats in my house.
+
+For the extremely extensive list of functions and the arguments they take, see
 
    $ inflect -pd
 
@@ -70,28 +108,41 @@ For the list of functions and the arguments they take, see
 
 =over 4
 
-=item FUNCTION
+=item FUNCTION arg [arg...]
 
-One of the Lingua::EN::Inflect functions.
+One of the Lingua::EN::Inflexion functions and arguments to it. For the
+function 'wordlist':
 
-=item "string..."
+  inflect wordlist [--conj [and|or]] \
+                   [--sep <separator character>] \
+                   [--[no]oxford \
+                   word [word word...]
+
+=over 4
+
+=item --conj - The default is 'and'. The other vcalid value is 'or'.
+
+=item --sep - The default separator is ',' or ';', depending on locale.
+
+=item --oxford - The default is to print the separator appearing before the conjugation.
+
+=back
+
+=item "string containg..."
 
 If there is only one argument, it is assumed to be a string that contains text
-and one or more of the Lingua::EN::Inflect functions. The string is passed to
-Lingua::EN::Inflect function 'inflect' which interpolates Lingua::EN::Inflect
-functions in strings.
+and one or more of the Lingua::EN::Inflexion functions. The string is passed to
+Lingua::EN::Inflexion function 'inflect' which interpolates
+Lingua::EN::Inflexion functions in strings.
 
     $ declare catcount=3
+    $ echo I have $(inflect '<#n:$catcount> <N: cat>') in my house.
     $ inflect "I have $catcount PL_N(cat,$catcount) in my house."
     I have 3 cats in my house.
 
 When forming the function calls inside an interpolated string, do not leave any
 space between the arguments, the parens and the commas. The L::E::I:inflect()'s
-parser fails with extra whitespace in some circumstances.
-
-=item args
-
-The arguments for the function.
+parser MAY fail with extra whitespace in some circumstances.
 
 =back
 
@@ -110,7 +161,7 @@ Print this help text.
 
 =item --pd
 
-Run 'perldoc Lingua::EN::Inflect'.
+Run 'perldoc Lingua::EN::Inflexion'.
 
 =back
 

--- a/bin/perl.mopenv
+++ b/bin/perl.mopenv
@@ -7,9 +7,15 @@ fi
 
 SYS_PERL=$(which perl -a)
 export SYS_PERL
-if [[ -f /opt/mop/perlbrew/etc/bashrc ]]; then
-    . /opt/mop/perlbrew/etc/bashrc
+if [[ -f "$OPTROOT/perlbrew/etc/bashrc" ]]; then
+    # shellcheck disable=SC1091 #https://github.com/koalaman/shellcheck/wiki/SC1091
+    . "$OPTROOT/perlbrew/etc/bashrc"
 fi
 
 PERLENV_LOADED=1
 export PERLENV_LOADED
+
+if [[ -f /opt/mop/perlbrew/etc/bashrc ]]; then
+    . /opt/mop/perlbrew/etc/bashrc
+fi
+

--- a/bin/post-any-install
+++ b/bin/post-any-install
@@ -2,7 +2,6 @@
 # shellcheck shell=bash
 # shellcheck disable=SC1090 #https://github.com/koalaman/shellcheck/wiki/SC1090
 # shellcheck disable=SC1091 #https://github.com/koalaman/shellcheck/wiki/SC1091
-# shellcheck disable=SC2154 #https://github.com/koalaman/shellcheck/wiki/SC2154
 
 ## post-any-install
 ## Instructions to build an environment after a new install.
@@ -10,9 +9,9 @@
 
 use on_exit
 
-declare pai_opt=$OPTROOT
 declare pai_opt_user=$USER
 declare pai_opt_os=''
+declare pai_restart_file=${HOME}/.config/pai.restart
 declare pai_log
 
 ## The array variables for this script are stored in 'post-any-install.data'
@@ -31,35 +30,108 @@ pai-ce-patch-progress () {
 }
 
 pai-patch () {
-    declare package=$1
-    declare package_idx=$2
-    declare package_count=$3
+    local package_name=$1
+    local package_patch_dir=$2
+    local package_idx=$2
+    local package_count=$3
 
-    package=${package/PATCHED:/}
-    declare parts
-    IFS='@' read -ra parts <<< "$package"
-    pai-ce-patch-progress "${parts[0]}" "$package_idx" "$package_count"
-    (
-        cd "${parts[1]}" || { false; return; }
-        pai-ce "Building in $PWD"
-        ./pai-patch || { false; return; }
-    )
-    true
+    local package_name
+    local package_location
+
+    pai-ce-patch-progress "${package_name}" "$package_idx" "$package_count"
+    pai-patch-dispatch "$package_name" "$package_patch_dir" || { false; exit; }
+    return $?
 }
 
 pai-get-workspace () {
-    if [[ ! -d $pai_opt ]]; then
-        pai-ce --ec "$pai_opt does not exist."
+    if [[ ! -d $OPTROOT ]]; then
+        pai-ce --ec "$OPTROOT does not exist."
         false; return
     fi
 
-    declare pai_workspace=${pai_opt}/post-any-install
+    local pai_workspace=${OPTROOT}/post-any-install
     if [[ ! -d $pai_workspace ]]; then
         sudo mkdir -p "$pai_workspace"
         sudo chown "${pai_opt_user}" "${pai_workspace}"
     fi
 
     cd "$pai_workspace" || { false; return; }
+}
+
+pai-restart-write () {
+    cat <<EOF >"${pai_restart_file}"
+${FUNCNAME[1]} $1
+EOF
+
+    pai-ce "Wrote restart file ${pai_restart_file}, Saving state '${FUNCNAME[1]}', '$1'."
+}
+
+pai-restart-read () {
+    local -n func=$1;shift
+    local -n object=$1;shift
+
+    if [[ -r "${pai_restart_file}" ]]; then
+        read -r func object < "${pai_restart_file}"
+        pai-ce "Read restart file ${pai_restart_file}. Restarting $func with $object."
+    fi
+}
+
+pai-restart-clean () {
+    if [[ -r "${pai_restart_file}" ]]; then
+        \rm -f "${pai_restart_file}"
+        if [[ ! -r "${pai_restart_file}" ]]; then
+            pai-ce "Removed restart file '${pai_restart_file}'"
+        else
+            pai-ce --ec "Did not remove restart file '${pai_restart_file}':$!"
+        fi
+    fi
+}
+
+pai-package-attribs-ok () {
+#set -x
+    local input=$1
+    local query=$2
+    if [[ -n $3 ]]; then
+        local -n value=$3
+    else
+        local value
+    fi
+    if [[ -n $4 ]]; then
+        local -n package=$4
+    else
+        local package
+    fi
+
+    local -a attribs
+    IFS='@' read -ra attribs <<< "$input"
+    package=${attribs[0]}
+    attribs=("${attribs[@]:1}")
+    local ok=0 # success
+    local id
+    local val
+    for attrib in "${attribs[@]}"; do
+        IFS='=' read -r id val <<< "$attrib"
+        if [[ $id == "$query" ]]; then
+            # shellcheck disable=SC2034 #https://github.com/koalaman/shellcheck/wiki/SC2034
+            value="$val"
+        fi
+
+        case $id in
+            os )
+                if [[ $val != "${pai_opt_os}" ]]; then
+                    pai-ce "Package $package limited to os $val. Skipping on $pai_opt_os..."
+                    ok=1 # failure
+                fi
+                ;;
+            patched )
+                # shellcheck disable=SC2034 #https://github.com/koalaman/shellcheck/wiki/SC2034
+                local noop # nothing to check
+                ;;
+        esac
+    done
+#set +x
+#pause
+    return $ok
 }
 
 # The '#action' tag is used to build the completion function and provide the
@@ -69,7 +141,7 @@ pai-get-workspace () {
 pai-sudo() { #action:wsl
     pai-ce 'Set up sudo'
 
-    declare sudoers_file=sudoers.$USER
+    local sudoers_file=sudoers.$USER
     cat <<EOSUDOERS >"$sudoers_file"
 $USER ALL=(ALL) NOPASSWD:ALL
 EOSUDOERS
@@ -92,15 +164,15 @@ pai-add-dpkg-repos () { #action
 
     ## Update the system
     pai-ce 'Update the system'
-    sudo apt update
-    sudo apt upgrade
+    sudo apt-get update
+    sudo apt-get upgrade
 }
 
 ## Add email support, primarily for cron
 pai-add-email-support () { #action
     pai-ce 'Add email support, primarily for cron'
 
-    sudo apt install -y --install-suggests ssmtp -y
+    sudo apt-get install -y --install-suggests ssmtp -y
 
     cat <<EOSSMTPCONF > ssmtp.conf
 root=matthew.persico@gmail.com
@@ -151,18 +223,35 @@ pai-check-passwd () { #action
 pai-debian-distro-packages () { #action
     pai-ce 'Install debian packages from distribution'
 
-    declare debian_package
-    # shellcheck disable=SC2154 #https://github.com/koalaman/shellcheck/wiki/SC2154
-    declare debian_package_count="${#pai_debian_distro_packages[@]}"
-    declare debian_package_idx=0
-    for debian_package in "${pai_debian_distro_packages[@]}"; do
-        echo
+    local restart_package=$1
+    if [[ -n $restart_package ]]; then
+        pai-ce "Restarting at $restart_package..."
+    fi
+
+    local debian_package_spec
+    local debian_package_count="${#pai_debian_distro_packages[@]}"
+    local debian_package_idx=0
+    local debian_package
+    for debian_package_spec in "${pai_debian_distro_packages[@]}"; do
         ((debian_package_idx+=1))
-        if [[ ! $debian_package =~ ^PATCHED: ]]; then
+
+        local debian_patch_dir # reset every loop
+        if [[ -n $restart_package && $restart_package != "$debian_package_spec" ]] \
+               || ! pai-package-attribs-ok "$debian_package_spec" 'patched' debian_patch_dir debian_package ; then
+            continue
+        fi
+        restart_package='' # Have to clear the restart if we hit it and got past it
+        echo
+
+        if [[ -z $debian_patch_dir ]]; then
             pai-ce-progress "$debian_package" "$debian_package_idx" "$debian_package_count"
-            sudo apt install -y --install-suggests "$debian_package"
+            if ! sudo apt-get install -y  "$debian_package"; then
+                pai-restart-write "$debian_package_spec"
+                false; return
+            fi
         else
-            if ! pai-patch "$debian_package" "$debian_package_idx" "$debian_package_count"; then
+            if ! pai-patch "$debian_package" "$debian_patch_dir" "$debian_package_idx" "$debian_package_count"; then
+                pai-restart-write "$debian_package_spec"
                 false; return
             fi
         fi
@@ -175,15 +264,32 @@ pai-debian-distro-packages () { #action
 pai-debian-local-packages () { #action
     pai-ce 'Install local debian packages'
 
-    declare debian_local_package
-    # shellcheck disable=SC2154 #https://github.com/koalaman/shellcheck/wiki/SC2154
-    declare debian_local_package_count="${#pai_debian_local_packages[@]}"
-    declare debian_local_package_idx=0
-    declare -a fdebian_local_packages # f => fully wildcard expanded
-    declare fdebian_local_package
-    for debian_local_package in "${pai_debian_local_packages[@]}"; do
-        echo
+    local debian_local_package_spec
+    local debian_local_package
+    local debian_local_package_count="${#pai_debian_local_packages[@]}"
+    if ((debian_local_package_count==0)); then
+        pai-ce -wc "No local debian packages to build."
+        true; return
+    fi
+
+    local restart_package=$1
+    if [[ -n $restart_package ]]; then
+        pai-ce "Restarting at $restart_package..."
+    fi
+
+    local debian_local_package_idx=0
+    local -a fdebian_local_packages # f => fully wildcard expanded
+    local fdebian_local_package
+    for debian_local_package_spec in "${pai_debian_local_packages[@]}"; do
         ((debian_local_package_idx+=1))
+
+        if [[ -n $restart_package && $restart_package != "$debian_local_package_spec" ]] \
+               || ! pai-package-attribs-ok "$debian_package_spec" '' '' debian_local_package ; then
+            continue
+        fi
+        restart_package='' # Have to clear the restart if we hit it and got past it
+        echo
+
         # shellcheck disable=SC2207 #https://github.com/koalaman/shellcheck/wiki/SC2207
         # shellcheck disable=SC2086 #https://github.com/koalaman/shellcheck/wiki/SC2086
         fdebian_local_packages=($(printf "%s\n" ${debian_local_package}*.deb | sed -e "s/^${debian_local_package}//" | sort -V | sed -e "s/^/${debian_local_package}/"))
@@ -192,7 +298,8 @@ pai-debian-local-packages () { #action
         fi
         if [[ ${#fdebian_local_packages[@]} == '0' ]]; then
             pai-ce -wc "$debian_local_package: No such package found."
-            continue
+            pai-restart-write "$debian_package"
+            false; return
         fi
         if (( ${#fdebian_local_packages[@]} > 1 )); then
             pai-ce -wc "$debian_local_package: More than one such package found."
@@ -206,55 +313,94 @@ pai-debian-local-packages () { #action
         fi
         if [[ $fdebian_local_package == 'Quit' ]] ; then break; fi
         pai-ce-progress "$fdebian_local_package" "$debian_local_package_idx" "$debian_local_package_count"
-        sudo apt install -y --install-suggests "$fdebian_local_package"
+        if ! sudo apt-get install -y "$fdebian_local_package"; then
+            pai-restart-write "$debian_local_package_spec"
+            false; return
+        fi
     done
 }
 
 pai-homebrew () { #action
     pai-ce 'Install homebrew packages'
 
-    curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > ./homebrew_install.sh || { false; return; }
-    chmod +x ./homebrew_install.sh
-    ./homebrew_install.sh
+    (
+        curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > ./homebrew_install_new.sh || { false; exit; }
+        if [[ ! -r ./homebrew_install.sh ]] || \
+               [[ $(sha256sum ./homebrew_install.sh | sed 's/ .*//') != $(sha256sum ./homebrew_install_new.sh | sed 's/ .*//') ]]; then
+            mv ./homebrew_install_new.sh ./homebrew_install.sh || { false; exit; }
+            chmod +x ./homebrew_install.sh || { false; exit; }
+            ./homebrew_install.sh  || { false; exit; }
+        else
+            pai-ce "$(brew --version) is already the latest available version."
+        fi
+    )
+    local rc=$?
+    if ((rc != 0)); then
+        pai-restart-write "No-package-for-homebrew-install"
+        false; return
+    fi
 }
 
 pai-homebrew-packages () { #action
     pai-ce "Install homebrew packages"
 
+    local restart_package=$1
+    if [[ -n $restart_package ]]; then
+        pai-ce "Restarting at $restart_package..."
+    fi
+
     # Install
-    declare homebrew_package
-    # shellcheck disable=SC2154 #https://github.com/koalaman/shellcheck/wiki/SC2154
-    declare homebrew_package_count="${#pai_homebrew_packages[@]}"
-    declare homebrew_package_idx=0
-    for homebrew_package in "${pai_homebrew_packages[@]}"; do
-        echo
+    local homebrew_package_spec
+    local homebrew_package_count="${#pai_homebrew_packages[@]}"
+    local homebrew_package_idx=0
+    local homebrew_package
+    for homebrew_package_spec in "${pai_homebrew_packages[@]}"; do
         ((homebrew_package_idx+=1))
+
+        if [[ -n $restart_package && $restart_package != "$homebrew_package_spec" ]] \
+               || ! pai-package-attribs-ok "$homebrew_package_spec" '' '' homebrew_package; then
+            continue
+        fi
+        restart_package='' # Have to clear the restart if we hit it and got past it
+        echo
+
         pai-ce-progress "$homebrew_package" "$homebrew_package_idx" "$homebrew_package_count)"
-        brew install "$homebrew_package"
+        if ! brew install "$homebrew_package"; then
+            pai-restart-write "$homebrew_package_spec"
+            false; return
+        fi
     done
 }
 
 pai-snap-packages () { #action
     pai-ce "Install snap packages"
 
-    if [[ ! -f $HOME/personal/bin/homebrew.mopenv ]]; then
-        pai-ce -ec "Environment file $HOME/personal/bin/homebrew.mopenv not found. No homebrew package installations will take place."
-    else
-        # shellcheck disable=SC1091 #https://github.com/koalaman/shellcheck/wiki/SC1091
-        . "$HOME"/personal/bin/homebrew.mopenv
-
-        # Install
-        declare snap_package
-        # shellcheck disable=SC2154 #https://github.com/koalaman/shellcheck/wiki/SC2154
-        declare snap_package_count="${#pai_snap_packages[@]}"
-        declare snap_package_idx=0
-        for snap_package in "${pai_snap_packages[@]}"; do
-            echo
-            ((snap_package_idx+=1))
-            pai-ce-progress "$snap_package" "$snap_package_idx" "$snap_package_count)"
-            brew install "$snap_package"
-        done
+    local restart_package=$1
+    if [[ -n $restart_package ]]; then
+        pai-ce "Restarting at $restart_package..."
     fi
+
+    # Install
+    local snap_package_spec
+    local snap_package_count="${#pai_snap_packages[@]}"
+    local snap_package_idx=0
+    local snap_package
+    for snap_package_spec in "${pai_snap_packages[@]}"; do
+        ((snap_package_idx+=1))
+
+        if ! pai-package-attribs-ok "$snap_package_spec" '' '' snap_package \
+             || [[ -n $restart_package && $restart_package != "$snap_package_spec" ]]; then
+            continue
+        fi
+        restart_package='' # Have to clear the restart if we hit it and got past it
+        echo
+
+        pai-ce-progress "$snap_package" "$snap_package_idx" "$snap_package_count)"
+        if ! sudo snap install "$snap_package"; then
+            pai-restart-write "$snap_package_spec"
+            false; return
+        fi
+    done
 }
 
 pai-system-perl-modules () { #action
@@ -266,41 +412,71 @@ pai-system-perl-modules () { #action
     fi
     pai-ce "Using $SYS_PERL as system perl."
 
-    # Bootstrap cpan
-    pai-ce "cpan bootstraps"
-    sudo "$SYS_PERL" -S cpan install CPAN
+    local restart_package=$1
+    if [[ -n $restart_package ]]; then
+        pai-ce "Restarting at $restart_package..."
+    fi
 
-    pai-ce "Update cpan itself..."
-    sudo "$SYS_PERL" -S cpan install Log::Log4perl Text::Levenshtein App::cpanminus
+    if [[ -z $restart_package || "$restart_package" == "CPAN" ]]; then
+        # Bootstrap cpan
+        pai-ce "cpan bootstraps"
+        if ! sudo "$SYS_PERL" -S cpan install CPAN; then
+            pai-restart-write "CPAN"
+            false; return
+        fi
+    fi
+
+    if [[ -z $restart_package || "$restart_package" == "CPAN-bootstrap" ]]; then
+        pai-ce "Update cpan itself..."
+        if ! sudo "$SYS_PERL" -S cpan install Log::Log4perl Text::Levenshtein App::cpanminus; then
+            pai-restart-write "CPAN-bootstrap"
+            false; return
+        fi
+    fi
 
     # Now get modules
     pai-ce "Now using the list..."
-    declare perl_module
-    # shellcheck disable=SC2154 #https://github.com/koalaman/shellcheck/wiki/SC2154
-    declare perl_module_count="${#pai_system_perl_modules[@]}"
-    declare perl_module_idx=0
-    for perl_module in "${!pai_system_perl_modules[@]}"; do
-        echo
+
+    local perl_module_spec
+    local perl_module_count="${#pai_system_perl_modules[@]}"
+    local perl_module_idx=0
+    local perl_module
+    local sys
+    for perl_module_spec in "${pai_system_perl_modules[@]}"; do
         ((perl_module_idx+=1))
-        declare sys=${pai_system_perl_modules[$perl_module]}
+
+        if ! pai-package-attribs-ok "$perl_module_spec" 'src' sys perl_module \
+             || [[ -n $restart_package && "$restart_package" != "$perl_module" ]]; then
+            continue
+        fi
+        restart_package='' # Have to clear the restart if we hit it and got past it
+        echo
+
+        local rc
         case $sys in
             debian)
                 pai-ce-progress "dpkg: $perl_module" "$perl_module_idx" "$perl_module_count"
-                sudo apt install -y --install-suggests "$perl_module"
+                sudo apt-get install -y "$perl_module"
+                rc=$?
                 ;;
             cpan)
-                declare pm="$perl_module"
+                local pm="$perl_module"
                 pm="${pm//__/::}"
-                pai-ce-progress  "cpan:$pm" " $perl_module_idx" "$perl_module_count"
+                pai-ce-progress  "cpan: $pm" " $perl_module_idx" "$perl_module_count"
                 sudo "$SYS_PERL" -S cpanm "$pm"
+                rc=$?
                 ;;
         esac
+        if ((rc!=0)); then
+            pai-restart-write "$perl_module"
+            false; return
+        fi
     done
 }
 
 pai-perlbrew-make-alias-name () {
-    declare perl_installation=$1
-    declare perl_installation_alias
+    local perl_installation=$1
+    local perl_installation_alias
     perl_installation_alias=${perl_installation#perl-}
     perl_installation_alias=${perl_installation_alias%.*}
     echo "$perl_installation_alias"
@@ -309,13 +485,20 @@ pai-perlbrew-make-alias-name () {
 pai-perlbrew () { #action
     pai-ce 'Install perlbrew and perl installations'
 
-    export PERLBREW_ROOT=/opt/mop/perlbrew
-    curl -L https://install.perlbrew.pl > ./perlbrew_install.sh || { false; return; }
-    chmod +x ./perlbrew_install.sh
-    ./perlbrew_install.sh
+    export PERLBREW_ROOT=$OPTROOT/perlbrew
+    curl -L https://install.perlbrew.pl > ./perlbrew_install_new.sh || { false; return; }
+    if [[ ! -r ./perlbrew_install.sh ]] || \
+           [[ $(sha256sum ./perlbrew_install.sh | sed 's/ .*//') != $(sha256sum ./perlbrew_install_new.sh | sed 's/ .*//') ]]; then
+        mv ./perlbrew_install_new.sh ./perlbrew_install.sh || { false; return; }
+        chmod +x ./perlbrew_install.sh || { false; return; }
+        ./perlbrew_install.sh  || { false; return; }
+    else
+        pai-ce "$(perlbrew --version) is already the latest available version."
+        true; return
+    fi
 
-    declare perlbrew_rc=$PERLBREW_ROOT/etc/bashrc
-    if ! grep $perlbrew_rc "$HOME/personal/bin/perl.mopenv" ; then
+    local perlbrew_rc=$PERLBREW_ROOT/etc/bashrc
+    if ! grep "$perlbrew_rc" "$HOME/personal/bin/perl.mopenv" ; then
         pai-ce "Adding '$perlbrew_rc' to '$HOME/personal/bin/perl.mopenv'..."
         cat << EOF >> "$HOME/personal/bin/perl.mopenv"
 
@@ -332,7 +515,7 @@ EOF
     perlbrew install-patchperl
 
     # List of perl versions we care about
-    declare -a perl_installations_to_install
+    local -a perl_installations_to_install
     if [[ -n $1 ]]; then
         perl_installations_to_install=("$@")
     else
@@ -341,15 +524,15 @@ EOF
 
     pai-ce "Installing perl versions ${perl_installations_to_install[*]}"
 
-    declare perl_installation
+    local perl_installation
     for perl_installation in "${perl_installations_to_install[@]}"; do
         if perlbrew install "$perl_installation"; then
 
             # Alias
-            declare perl_installation_alias
+            local perl_installation_alias
             perl_installation_alias=$(pai-perlbrew-make-alias-name "$perl_installation")
             if perlbrew alias create "$perl_installation" "$perl_installation_alias" 2>&1 | grep -q 'already exists'; then
-                declare existing_alias_value
+                local existing_alias_value
                 existing_alias_value=$(perlbrew exec --with "$perl_installation_alias" perl -e '$v=$^V;$v=~s/v/perl-/;print $v')
                 pai-ce "Moving existing alias $perl_installation_alias from $existing_alias_value to $perl_installation"
                 perlbrew alias delete "$perl_installation_alias"
@@ -364,7 +547,6 @@ EOF
 pai-perlbrew-modules () { #action
     pai-ce "Install CPAN modules to perlbrew"
 
-    # shellcheck disable=SC2031 #https://github.com/koalaman/shellcheck/wiki/SC2031
     if [[ -z $PERLBREW_ROOT ]]; then
         pai-ce "perlbrew not initialized in this shell. Will source \"$PERLBREW_ROOT/etc/bashrc\"."
         source "$PERLBREW_ROOT/etc/bashrc"
@@ -372,13 +554,13 @@ pai-perlbrew-modules () { #action
 
     # Bootstrap. This installation is good across all perlbrew perls. But date
     # check it.
-    declare pai_pbm_date_file="$HOME/.config/pai-perlbrew-modules-date"
+    local pai_pbm_date_file="$HOME/.config/pai-perlbrew-modules-date"
     if [[ ! -f $pai_pbm_date_file ]]; then
         date +%s > "$pai_pbm_date_file"
     fi
-    declare pai_pbm_date_last
+    local pai_pbm_date_last
     pai_pbm_date_last=$(cat "$pai_pbm_date_file")
-    declare now
+    local now
     now=$(date +%s)
     if ((now - pai_pbm_date_last> 60 * 60 * 24)); then
         perlbrew install-cpanm --force
@@ -388,7 +570,7 @@ pai-perlbrew-modules () { #action
     fi
 
     # List of perl versions we care about
-    declare perl_installations
+    local perl_installations
     if [[ -n $1 ]]; then
         ajoin perl_installations -s , "$@"
     else
@@ -396,23 +578,38 @@ pai-perlbrew-modules () { #action
     fi
     pai-ce "Installing modules in $perl_installations"
 
+    local restart_package=$1
+    if [[ -n $restart_package ]]; then
+        pai-ce "Restarting at $restart_package..."
+    fi
+
     # Install
-    declare perl_module
-    # shellcheck disable=SC2154 #https://github.com/koalaman/shellcheck/wiki/SC2154
-    declare perl_module_count="${#pai_perl_modules[@]}"
-    declare perl_module_idx=0
-    for perl_module in "${pai_perl_modules[@]}"; do
-        echo
+    local perl_module_spec
+    local perl_module_count="${#pai_perl_modules[@]}"
+    local perl_module_idx=0
+    local perl_module
+    local perl_patch_dir
+    for perl_module_spec in "${pai_perl_modules[@]}"; do
         ((perl_module_idx+=1))
-        if [[ ! $perl_module =~ ^PATCHED: ]]; then
+
+        perl_patch_dir='' # reset every loop
+        if ! pai-package-attribs-ok "$perl_module_spec" 'patched' perl_patch_dir perl_module \
+             || [[ -n $restart_package && $restart_package != "$perl_module_spec" ]] ; then
+            continue
+        fi
+        restart_package='' # Have to clear the restart if we hit it and got past it
+        echo
+
+        if [[ -z $perl_patch_dir ]]; then
             pai-ce-progress "$perl_module" "$perl_module_idx" "$perl_module_count"
             if ! perlbrew exec --with "$perl_installations" cpanm "$perl_module"; then
-                pai-ce --ec "$perl_module... ($perl_module_idx/$perl_module_count)  $(date)"
                 cat "$HOME/.cpanm/build.log"
-                break
+                pai-restart-write "$perl_module_spec"
+                false; return
             fi
         else
-            if ! pai-patch "$perl_module" "$perl_module_idx" "$perl_module_count"; then
+            if ! pai-patch "$perl_module" "$perl_patch_dir" "$perl_module_idx" "$perl_module_count"; then
+                pai-restart-write "$perl_module_spec"
                 false; return
             fi
         fi
@@ -427,11 +624,14 @@ pai-perlbrew-modules () { #action
 pai-build-oss () { #action
 
     # Set up the install dir
-    declare build_root="${pai_opt}/build"
+    local build_root="${OPTROOT}/build"
     if [[ ! -d $build_root ]]; then
         sudo mkdir -p "${build_root}"
         sudo chown -R "${USER}:${USER}" "${build_root}"
     fi
+
+    declare return_to
+    return_to=$(pwd)
     cd "${build_root}" || { false; return; }
     github-clone matthewpersico/oss
     cd oss || { false; return; }
@@ -445,43 +645,51 @@ pai-build-oss () { #action
             git push -u origin "$(hostname)"
         fi
     )
-    declare git_dq=$?
-    if ((git_dq != 0)); then
+    local rc=$?
+    if ((rc)); then
+        cd "$return_to" || exit
         false; return
     fi
 
     # Build and install everything
-    declare prog
+    local prog
     for prog in "${build_root}"/*; do
         (
-            cd "$prog" || { false; return; }
-            declare ver
-            # shellcheck disable=SC2012 #https://github.com/koalaman/shellcheck/wiki/SC2012
-            ver=$(ls -c1 | sort -V | tail -1)
-            build-oss --clean "$prog" "$ver"
+            cd "$prog" || { false; exit; }
+            local ver
+            ver=$(basename "$(find . -maxdepth 1 | sort -V | tail -1 )")
+            build-oss "$prog" "$ver"
         )
-    done
-
-    # Set up the branch sync for the repo
-    github-clone --tree matthewpersico/oss
-    declare -a branches
-    mapfile branches < <(git branch --list --remote | grep -v -- '->' | grep origin/ | sed 's/origin\///')
-    for branch in "${branches[@]}"; do
-        if ! git branch --list | grep -E "\* $branch$"; then
-            git checkout -b "$branch" --track "origin/$branch"
+        local rc=$?
+        if ((rc)); then
+            false; return
         fi
     done
+
+    # Set up the repo for branch syncing.
+    declare repo_dir
+    repo_dir=$(git-go --listfull oss)
+    if [[ -z "$repo_dir" ]]; then
+        github-clone --tree matthewpersico/oss
+        local -a branches
+        mapfile branches < <(git branch --list --remote | grep -v -- '->' | grep origin/ | sed 's/origin\///')
+        for branch in "${branches[@]}"; do
+            if ! git branch --list | grep -E "\* $branch$"; then
+                git checkout -b "$branch" --track "origin/$branch"
+            fi
+        done
+    fi
 }
 
 main () {
-    source "post-any-install.data"
+    source "$(dirname "$0")/post-any-install.data"
 
     # Read the options and args from command line. Note that the long and short
     # don't have to match up.
-    declare OPTSARGS
-    declare shortopts=''
-    declare longopts='os:,nolog,no-log'
-    declare opt_log=1
+    local OPTSARGS
+    local shortopts=''
+    local longopts='os:,nolog,no-log'
+    local opt_log=1
 
     # Process the command line.
     OPTSARGS=$(getopt -a -o "$shortopts" -l "${longopts}" -n "${FUNCNAME[0]}" -- "$@") || return
@@ -491,7 +699,7 @@ main () {
 
     # Reprocess the command line, extracting options and their arguments into
     # variables.
-    declare option
+    local option
     while [[ $1 =~ ^- ]]; do
         option=$1
         shift
@@ -543,17 +751,17 @@ main () {
     fi
 
     # This is the default order to run in if specifying 'all'.
-    declare -a actions_data
+    local -a actions_data
     mapfile -t actions_data < <(grep '()\s*{\s*#action' "$0" )
 
-    declare -a valid_actions_list
-    declare -A valid_actions_os_map
+    local -a valid_actions_list
+    local -A valid_actions_os_map
     for data in "${actions_data[@]}"; do
-        declare action
+        local action
         action=$(sed -e 's/^pai-//' -e 's/\s*().*//' <<< "$data")
         valid_actions_list+=("$action")
 
-        declare os
+        local os
         os=$(sed -E -e 's/.*#action(:){0,1}\s*//' <<< "$data")
         [[ -z $os ]] && os=$pai_opt_os
         valid_actions_os_map[$action]=$os
@@ -569,12 +777,27 @@ main () {
         true; exit
     fi
 
-    declare action
-    declare -a execute
+    local action
+    local -a execute
     while (($#)); do
         action=$1
         shift;
-        if [[ $action == 'all' ]]; then
+        if [[ $action != 'restart' ]] && \
+           [[ -r "${pai_restart_file}" ]]; then
+            pai-ce "Restart file '${pai_restart_file}' found. Either rerun with action 'restart' or remove the file before rerunning."
+            false; exit
+        fi
+        if [[ $action == 'restart' ]]; then
+            if [[ ! -r "${pai_restart_file}" ]]; then
+                pai-ce "Restart file '${pai_restart_file} found not found. Rerun with a different action."
+                false; exit
+            else
+                local restart_action
+                local restart_object
+                pai-restart-read restart_action restart_object
+                execute+=("$restart_action~~~$restart_object")
+            fi
+        elif [[ $action == 'all' ]]; then
             execute=("${valid_actions_list[@]}")
             break
         elif [[ -n ${valid_actions_os_map[$action]} ]]; then
@@ -588,13 +811,26 @@ main () {
     source "$(realpath "$0").data"
 
     for action in "${execute[@]}"; do
+        local func_name
+        local -a func_args
+
+        if [[ $action =~ ~~~ ]]; then
+            func_name=${action%%~~~*}
+            func_args+=("${action##*~~~}")
+        else
+            func_name="pai-$action"
+        fi
+
         if [[ "$pai_opt_os" =~ ${valid_actions_os_map[$action]} ]] ;then
-            declare func_name="pai-$action"
-            "$func_name" || exit
+            pai-ce --debug "$func_name" "${func_args[@]}"
+            "$func_name" "${func_args[@]}" || exit
         else
             pai-ce --ec "$action only available on ${valid_actions_os_map[$action]}, not $pai_opt_os. Skipping..."
         fi
+
     done
+
+    pai-restart-clean
 }
 
 main "$@"

--- a/bin/post-any-install.data
+++ b/bin/post-any-install.data
@@ -13,29 +13,29 @@ declare -a pai_perlbrew_installations=(
 _pai_system_perl_modules () {
     :
 }
-declare -A pai_system_perl_modules=(
-    ['libcpan-perl-releases-perl']='debian'
-    ['libdevel-ptkdb-perl']='debian'
-    ['libemail-sender-perl']='debian'
-    ['libemail-simple-perl']='debian'
-    ['libfile-path-tiny-perl']='debian'
-    ['libfile-slurp-perl']='debian'
-    ['libjson-xs-perl']='debian'
-    ['liblingua-en-inflect-perl']='debian'
-    ['liblist-moreutils-perl']='debian'
-    ['liblist-moreutils-xs-perl']='debian'
-    ['liblocale-gettext-perl']='debian'
-    ['libppi-perl']='debian'
-    ['libppi-xs-perl']='debian'
-    ['libterm-readline-gnu-perl']='debian'
-    ['libterm-readline-perl-perl']='debian'
-    ['perl-doc']='debian'
-    ['perl-tk']='debian'
-    ['perltidy']='debian'
+declare -a pai_system_perl_modules=(
+    'libcpan-perl-releases-perl@src=debian'
+    'libdevel-ptkdb-perl@src=debian'
+    'libemail-sender-perl@src=debian'
+    'libemail-simple-perl@src=debian'
+    'libfile-path-tiny-perl@src=debian'
+    'libfile-slurp-perl@src=debian'
+    'libjson-xs-perl@src=debian'
+    'liblingua-en-inflect-perl@src=debian'
+    'liblist-moreutils-perl@src=debian'
+    'liblist-moreutils-xs-perl@src=debian'
+    'liblocale-gettext-perl@src=debian'
+    'libppi-perl@src=debian'
+    'libppi-xs-perl@src=debian'
+    'libterm-readline-gnu-perl@src=debian'
+    'libterm-readline-perl-perl@src=debian'
+    'perl-doc@src=debian'
+    'perl-tk@src=debian'
+    'perltidy@src=debian'
 
-
-    ['Rand__Urandom']='cpan'
-    ['Term__Menus']='cpan'
+    'Lingua::EN::Inflexion@src=cpan'
+    'Rand::Urandom@src=cpan'
+    'Term::Menus@src=cpan'
 )
 
 # Anything in non alphabetical order is a prereq of something else.
@@ -44,8 +44,7 @@ _pai_perl_modules () {
 }
 declare -a pai_perl_modules=(
     # 800.036 fails to build unpatched.
-    "PATCHED:Tk@$HOME/gits/github/matthewpersico/perl-tk/wt/fix-rt-154121"
-
+    "Tk@patched=$HOME/gits/github/matthewpersico/perl-tk/wt/fix-rt-154121"
     App::cpanminus
     App::FatPacker
     App::ModuleBuildTiny
@@ -80,6 +79,7 @@ declare -a pai_perl_modules=(
     JSON::PP
     JSON::XS
     Lingua::EN::Inflect
+    Lingua::EN::Inflexion
     List::MoreUtils
     List::MoreUtils::XS
     Log::Log4perl
@@ -102,7 +102,6 @@ declare -a pai_perl_modules=(
     Term::ReadKey
     Term::ReadLine
     Term::ReadLine::Gnu
-    Term::ReadLine::Perl
     Term::UI
     Test::More
     Test::Perl::Critic
@@ -129,14 +128,16 @@ _pai_debian_distro_packages () {
 }
 
 declare -a pai_debian_distro_packages=(
+    autopoint
     brave-browser
+    bubblewrap
     build-essential
     calibre
     clangd
     cmake
     csh
+    'code@os=rpi' ## This is vscode. Way to go with the naming, Microsoft ...
     curl
-    devscripts
     dos2unix
     gcc
     groff
@@ -157,12 +158,13 @@ declare -a pai_debian_distro_packages=(
     mandoc
     make
     nedit
+    node-semver
     nvme-cli
     pandoc
     rename
-    semver
     shellcheck
     smartmontools
+    snapd
     snap
     speech-dispatcher
     wish
@@ -176,8 +178,8 @@ declare -a pai_debian_distro_packages=(
     xfonts-75dpi
     xfonts-base
     xfonts-utils
-    # skipping yad - we have a patch for specifying default button choice. Build and install the patched version in
-    "PATCHED:yad@$HOME/gits/github/matthewpersico/yad/wt/set-default-button-focus"
+    # skipping yad - we have a patch for specifying default button choice.
+    "yad@patched=$HOME/gits/github/matthewpersico/yad/wt/set-default-button-focus"
     zsh
 )
 
@@ -194,11 +196,53 @@ declare -a pai_homebrew_packages=(
     gcc
     uv
     bashdb
+    tailscale
 )
 
 _pai_snap_packages () {
     :
 }
 declare -a pai_snap_packages=(
-    code ## This is vscode. Way to go with the naming, Microsoft ...
+    'code@os=wsl' ## This is vscode. Way to go with the naming, Microsoft ...
 )
+
+pai-patch-dispatch () {
+    local package_name=$1
+    local package_location=$2
+
+    (
+        cd "${package_location}" || { false; exit; }
+        pai-ce "Building in $PWD"
+
+        if [[ ! -r  pai-patch.timestamp ]] \
+               || find . -type f -newer pai-patch.timestamp -print -quit | grep -q . ; then
+            case $package_name in
+                yad )
+                    pai-ce-progress "autoreconf -fi" 1 4
+                    autoreconf -fi || exit
+                    pai-ce-progress "./configure --prefix=/opt/mop" 2 4
+                    ./configure --prefix=/opt/mop  || exit
+                    pai-ce-progress "make -j4" 3 4
+                    make -j4  || exit
+                    pai-ce-progress "sudo make install" 4 4
+                    sudo make install || exit
+                    ;;
+                Tk )
+                    pai-ce-progress "git drc" 1 3
+                    git drc || exit
+                    pai-ce-progress "perl Makefile.PL" 1 3
+                    perl Makefile.PL || exit
+                    pai-ce-progress "make install" 1 3
+                    make install || exit
+                    ;;
+            esac
+        else
+            pai-ce "${package_name} is up to date."
+        fi
+    )
+    local rc=$?
+    if ((rc==0)); then
+        date +%s >  "${package_location}"/pai-patch.timestamp
+    fi
+    return $rc
+}

--- a/bin/webperldoc
+++ b/bin/webperldoc
@@ -1,0 +1,75 @@
+# -*- sh -*-
+# shellcheck shell=bash
+
+# webperldoc - perldoc to a browser
+
+# Useful function packages
+# use on_exit # Sets up traps
+# use mktemp  # Sets up and clears temp files
+
+# Stricter behaviors.
+# set -e # Exit if a command fails (-e).
+# set -u # Exit if an unset variable is referenced (-u).
+# set -o pipefail # Exit pipeline at the failed command with the failed exit code
+
+main ()
+{
+    # GNU getopt cannot passthrough unrecognized options. So, we don't use it here.
+    if [[ $1 == '-h' || $1 == '-help' ]]; then
+        bash-usage "$0"
+    fi
+    tmp=$(mktemp --suffix=.html)
+    trap 'rm -f "$tmp"' EXIT
+
+    perldoc -o html "$@" >"$tmp" || exit
+    xdg-open "$tmp"
+
+    # Keep the file around until the browser has opened it.
+    sleep 10
+}
+
+# Other functions here
+
+# Execution starts here
+main "$@"
+
+# Exit here with status code returned from main.
+:<<'__PODUSAGE__'
+=head1 NAME
+
+webperldoc - run perldoc into a browser
+
+=head1 SYNOPSIS
+
+ webperldoc [-h|--help]
+ webperldoc <perldoc options and args>
+
+=head1 DESCRIPTION
+
+Run perldoc -o html into a temp file and then xdg-open that file. Give 30
+seconds before the temp file is delete.
+
+=head1 ARGUMENTS
+
+All arguments are passed down to perldoc.
+
+=head1 OPTIONS
+
+=over 4
+
+=item --help | -h
+
+Presents this help, not sent to a browser. For perldoc help, use 'webperldoc
+perldoc'.
+
+=item everything else
+
+All other options are passed down to perldoc. Don't be a smart-aleck and pass
+an overriding -o formatting option; results are indeterminate and it probably
+won't work.
+
+=back
+
+=cut
+
+__PODUSAGE__

--- a/bin/wordlist
+++ b/bin/wordlist
@@ -1,0 +1,1 @@
+inflect

--- a/bin/xo
+++ b/bin/xo
@@ -8,208 +8,246 @@
 ## Filters in where parent ppid is 1 (in case emacs is running a perl debugger
 ## or some other subprocess)
 
+xo-ce () {
+    cmd-echo --id xo "$@"
+}
+
+declare emacs_exe
+emacs_exe=$(type -P emacs)
+if [[ -z $emacs_exe ]] ; then
+    xo-ce --ec "No emacs executable found. Bye!"
+    false; exit
+fi
+
 use mktemp
 use on_exit
 
-debug=0
-forceX=0
-emacs_exe=$(type -P emacs)
-if [[ -z $emacs_exe ]] ; then
-    echo "No emacs executable found. Bye!"
-    false; exit
-fi
-emacsclient_exe="${emacs_exe}client"
-declare -a git_is_mod ## These are modified files in a git repo
-declare -a which      ## We used to use the 'which' utility to find these
-declare -a org        ## The org file
-declare as_visual=0
-declare new_frame=0
-declare more_opts=1
-declare nobg=0
-declare use_rc=1
-declare xo_verbose=0
-declare files_only=0
-declare stdin_file=''
-declare opt_iso=0
-declare serverup=0
+main () {
+    debug=0
+    forceX=0
+    emacsclient_exe="${emacs_exe}client"
+    local -a git_is_mod ## These are modified files in a git repo
+    local -a which      ## We used to use the 'which' utility to find these
+    local -a org        ## The org file
+    local as_visual=0
+    local new_frame=0
+    local nobg=0
+    local use_rc=1
+    local xo_verbose=0
+    local files_only=0
+    local stdin_file=''
+    local opt_iso=0
+    local serverup=0
+    local force_x=0
+    local -a emacs_opts
 
-declare -a emacs_opts
-while ((more_opts)) && [[ "$1" =~ ^- ]]; do
-    original="$1"
-    option=$(dashstripper "$1")
-    shift ## That way you avoid endless loops on invalid options.
+    # Set up args and options.
+    local OPTSARGS
+    local orig_args="$*"
+    local shortopts='xS:h'
+    local longopts1='geo-only,nobg,debug-init,debug,forceX,which:,root:,exe:'
+    local longopts2='gim,nf,todo,org,norc,xov,fo,files-only,std:stdin-file:'
+    local longopts3='iso,isolated,force-x,help,visual'
+    local longopts="${longopts1},${longopts2},${longopts3}"
+    OPTSARGS=$(getopt -a -o "$shortopts" -l "$longopts" -n "$(basename "$0")" -- "$@") || exit
 
-    case $option in
-        geo-only )
-            declare rootx=$(( $(x-current-root -w)/2 ))
-            declare rooty=$(( $(x-current-root -h)/6 ))
-            if ((nobg)); then
-                $emacs_exe -g +${rootx}+${rooty} "$@"
-            else
-                $emacs_exe -g +${rootx}+${rooty} "$@" &
-            fi
-            true; exit
-            ;;
-        nobg )
-            nobg=1
-            ;;
-        debug-init )
-            emacs_opts+=('--debug-init') ;;
-        debug | x ) set -x; debug=1 ;; # OK if you are grepping
-        forceX ) forceX=1 ;;
-        which )
-            declare tmp
-            tmp=$(type -P "$1")
-            shift
-            if [[ -z "$tmp" ]]; then
-                cmd-echo --id xo -wc -- "$1 not found; skipping"
-            else
-                which+=("$tmp")
-            fi
-            ;;
-        root )
-            emacs_exe="$1/emacs"
-            emacsclient_exe="$1/emacsclient"
-            declare i
-            for i in $emacs_exe $emacsclient_exe; do
-                [[ -x "$i" ]] || (cmd-echo --id xo "Cannot find '$i'. --root cannot be used." && { false; exit; });
-            done
-            shift
-            ;;
-        exe )
-            emacs_exe="$1"
-            emacsclient_exe="${1}client"
-            declare i
-            for i in $emacs_exe $emacsclient_exe; do
-                [[ -x "$i" ]] || (cmd-echo --id xo "Cannot find '$i'. --root cannot be used." && { false; exit; });
-            done
-            shift
-            ;;
-        gim )
-            if git repo isa; then
-                mapfile -t git_is_mod < <(git what is mod 2>/dev/null)
-                if [[ -z "${git_is_mod[0]}" ]]; then
-                    if ! git root 2>/dev/null 1>&2; then
-                        cmd-echo --id xo -- "--gim not allowed; not in a git repo"
-                    else
-                        cmd-echo --id xo -- "No modified git files found."
-                    fi
-                    false; exit
+    # Reset the command line ($@).
+    eval set -- "$OPTSARGS"
+
+    # Reprocess the command line, extracting options. Options stop at '-- or
+    # the first string that does not start with a -. If there are strings that
+    # are values for the options, they probably will not start with
+    # dashes. However, they are processed and shifted off before we get back to
+    # this comparison.
+    while [[ $1 =~ ^- ]] ; do
+        original="$1"
+        local option=$1
+        shift
+        [[ "$option" != '--' ]] && option=${option##-} && option=${option##-}
+        ###############################################################
+        ## HEADS UP! There is now a completion function _xo_completion
+        ## that needs to be kept in sync with all the options here.
+        case $option in
+            geo-only )
+                local rootx=$(( $(x-current-root -w)/2 ))
+                local rooty=$(( $(x-current-root -h)/6 ))
+                if ((nobg)); then
+                    $emacs_exe -g +${rootx}+${rooty} "$@"
+                else
+                    $emacs_exe -g +${rootx}+${rooty} "$@" &
                 fi
-            else
-                cmd-echo --id xo "${PWD} is not a git repo. --gim ignored"
-            fi
-            ;;
-        nf )
-            new_frame=1
-            ;;
-        todo | org )
-            org=("$HOME/todo.org")
-            ;;
-        norc )
-            use_rc=0
-            ;;
-        xov )
-            xo_verbose=1
-            ;;
-        fo | files-only )
-            files_only=1
-            ;;
-        std| stdin-file )
-            stdin_file=$1
-            shift
-            ;;
-        iso | isolated )
-            opt_iso=1
-            ;;
-        help )
-            bash-usage "$0"; { true; exit; } ;;
-        -- )
-            more_opts=0
-            ;;
-        * )
-            cmd-echo --id xo -- "$original is an invalid option. See $0 --help"; { false; exit; } ;;
-    esac
-done
+                true; exit
+                ;;
+            nobg )
+                nobg=1
+                ;;
+            debug-init )
+                emacs_opts+=('--debug-init') ;;
+            debug | x ) set -x; debug=1 ;; # OK if you are grepping
+            forceX ) forceX=1 ;;
+            which | S)
+                local tmp
+                tmp=$(type -P "$1")
+                shift
+                if [[ -z "$tmp" ]]; then
+                    xo-ce -wc -- "$1 not found; skipping"
+                else
+                    which+=("$tmp")
+                fi
+                ;;
+            root | exe )
+                case $option in
+                    root )
+                        emacs_exe="$1/emacsdsdsds"
+                        emacsclient_exe="$1/emacsdsdssclient"
+                        ;;
+                    exe)
+                        emacs_exe="$1"
+                        emacsclient_exe="${1}client"
+                        ;;
+                esac
+                local i
+                local -a missing
+                for i in $emacs_exe $emacsclient_exe; do
+                    [[ ! -x "$i" ]] && missing+=("$i")
+                done
+                if [[ -n ${missing[0]} ]]; then
+                    xo-ce "Cannot find ${missing[*]}, $1 cannot be used for --$option." && { false; exit; };
+                fi
+                shift
+                ;;
+            gim )
+                if git repo isa; then
+                    mapfile -t git_is_mod < <(git what is mod 2>/dev/null)
+                    if [[ -z "${git_is_mod[0]}" ]]; then
+                        if ! git root 2>/dev/null 1>&2; then
+                            xo-ce -- "--gim not allowed; not in a git repo"
+                        else
+                            xo-ce -- "No modified git files found."
+                        fi
+                        false; exit
+                    fi
+                else
+                    xo-ce "${PWD} is not a git repo. --gim ignored"
+                fi
+                ;;
+            nf )
+                new_frame=1
+                ;;
+            todo | org )
+                org=("$HOME/todo.org")
+                ;;
+            norc )
+                use_rc=0
+                ;;
+            xov )
+                xo_verbose=1
+                ;;
+            fo | files-only )
+                files_only=1
+                ;;
+            std| stdin-file )
+                stdin_file=$1
+                shift
+                ;;
+            iso | isolated )
+                opt_iso=1
+                ;;
+            force-x )
+                force_x=1
+                ;;
+            help | h )
+                bash-usage "$0"; { true; exit; } ;;
+            -- ) break ;; ## VITAL!!! Exits the while loop, no more options,
+            ## remaining $*, if any, are args
+            * )
+                echo "<buffer-name>: '$original' is an invalid option."
+                echo "<buffer-name>: args: '$orig_args'"
+                local i
+                for (( i=${#BASH_SOURCE[@]}-1; i>=0; i-- )); do
+                    printf "  %s at %s:%s\n" "${FUNCNAME[i]}" "${BASH_SOURCE[i]}" "${BASH_LINENO[i]}"
+                done
+                false; exit
+                ;;
+        esac
+    done
 
-## Temp file for processing and diagnostic messages.
-procs=$(mktempfile xo.$$)
-rm_on_exit "$procs"
+    ## Temp file for processing and diagnostic messages.
+    procs=$(mktempfile xo.$$)
+    rm_on_exit "$procs"
 
-##
-## Main
-##
+    OS=$(uname -s)
 
-OS=$(uname -s)
-
-## Assume X or some other windowing system is available and do the needful if
-## not.
-hasX=1
-if [[ "$forceX" = '1' ]]; then
+    ## Assume X or some other windowing system is available and do the needful if
+    ## not.
     hasX=1
-elif [[ ! "$OS" = 'Cygwin' ]]; then
-    if ! type -P xmodmap >/dev/null; then
-        hasX=0
-    else
-        if xmodmap 2>&1 | grep -q 'unable to open display'; then
+    if [[ "$forceX" = '1' ]]; then
+        hasX=1
+    elif [[ ! "$OS" = 'Cygwin' ]]; then
+        if ! type -P xmodmap >/dev/null; then
             hasX=0
-        fi
-    fi
-fi
-
-if (( opt_iso == 0 )) ; then
-    ## See if there is a server running
-    if [[ -e $XDG_RUNTIME_DIR/emacs/server ]]; then
-        serverup=1
-    fi
-    if ((debug)); then
-        echo "serverup = $serverup"
-    fi
-
-    ## If we are being used as the git editor or EDITOR, we don't want to start
-    ## up such that the underlying process thinks we're done editing before we
-    ## are.
-    if [[ "$1" = '--visual' ]]; then
-        as_visual=1
-        shift
-    elif [[ "$1" = '--nf' ]] || [[ "$1" = '-nf' ]]; then
-        new_frame=1
-        shift
-    fi
-fi
-declare -a allfiles
-if [[ -p /dev/stdin ]]; then
-    if [[ -z $stdin_file ]]; then
-        stdin_file=$(mktempfile)
-        rm_on_exit "$stdin_file"
-    fi
-    declare tmpline
-    while read -r tmpline; do echo "$tmpline"; done > "$stdin_file"
-    allfiles=("$stdin_file")
-else
-    allfiles=("$@" "${org[@]}" "${git_is_mod[@]}" "${which[@]}")
-    if ((use_rc)) && [[ -r ./xo.rc ]] && [[ ${#allfiles[@]} == '0' ]]; then
-        declare xorcline
-        while read -r xorcline; do
-            declare -a xorcline_a
-            read -a xorcline_a -r <<< "$xorcline"
-            allfiles+=("${xorcline_a[@]}")
-        done < ./xo.rc
-        if (( ${#allfiles[@]} )); then
-            cmd-echo --id xo -- "Loading these files from ./xo.rc:" "${allfiles[@]}"
+        else
+            if xmodmap 2>&1 | grep -q 'unable to open display'; then
+                hasX=0
+            fi
         fi
     fi
 
-    if ((files_only)); then
-        declare tmpf
-        for tmpf in "${allfiles[@]}"; do
-            [[ -f $tmpf ]] && tmpa+=("$tmpf");
-        done
-        allfiles=("${tmpa[@]}")
-    fi
+    if (( opt_iso == 0 )) ; then
+        xo-ce "remaining args: $*"
+        ## See if there is a server running
+        if [[ -e $XDG_RUNTIME_DIR/emacs/server ]]; then
+            serverup=1
+        fi
+        if ((debug)); then
+            echo "serverup = $serverup"
+        fi
 
-    declare -a allfilesparsed
-    read -r -a allfilesparsed < <(perl -e '
+        ## If we are being used as the git editor or EDITOR, we don't want to start
+        ## up such that the underlying process thinks we're done editing before we
+        ## are.
+        ## TODO: Why in the world are we processing $1 and options here???
+        if [[ "$1" = '--visual' ]]; then
+            as_visual=1
+            shift
+        elif [[ "$1" = '--nf' ]] || [[ "$1" = '-nf' ]]; then
+            new_frame=1
+            shift
+        fi
+    fi
+    local -a allfiles
+    if [[ -p /dev/stdin ]]; then
+        if [[ -z $stdin_file ]]; then
+            stdin_file=$(mktempfile)
+            rm_on_exit "$stdin_file"
+        fi
+        local tmpline
+        while read -r tmpline; do echo "$tmpline"; done > "$stdin_file"
+        allfiles=("$stdin_file")
+    else
+        allfiles=("$@" "${org[@]}" "${git_is_mod[@]}" "${which[@]}")
+        if ((use_rc)) && [[ -r ./xo.rc ]] && [[ ${#allfiles[@]} == '0' ]]; then
+            local xorcline
+            while read -r xorcline; do
+                local -a xorcline_a
+                read -a xorcline_a -r <<< "$xorcline"
+                allfiles+=("${xorcline_a[@]}")
+            done < ./xo.rc
+            if (( ${#allfiles[@]} )); then
+                xo-ce -- "Loading these files from ./xo.rc:" "${allfiles[@]}"
+            fi
+        fi
+
+        if ((files_only)); then
+            local tmpf
+            for tmpf in "${allfiles[@]}"; do
+                [[ -f $tmpf ]] && tmpa+=("$tmpf");
+            done
+            allfiles=("${tmpa[@]}")
+        fi
+
+        local -a allfilesparsed
+        read -r -a allfilesparsed < <(perl -e '
 for (@ARGV) {
   @s = split(/:/, $_);
   if($s[-1] =~ m/^[0-9]+$/) {
@@ -221,61 +259,70 @@ for (@ARGV) {
     print qq($_ );
   }
 } ' "${allfiles[@]}")
-    allfiles=("${allfilesparsed[@]}")
-fi
+        allfiles=("${allfilesparsed[@]}")
+    fi
 
-if ((serverup==0)); then
-    if ((as_visual==0)) && ((new_frame==0)); then
-        if (( hasX )); then
-            declare rootx=$XTERMGEO_X
-            declare rooty=$XTERMGEO_Y
-            if ((nobg)); then
-                ((xo_verbose)) && set -x # OK if you are grepping
-                $emacs_exe -g "+${rootx}+${rooty}" \
-                           "${emacs_opts[@]}" "${allfiles[@]}"
-                ((xo_verbose)) && set +x # OK if you are grepping
+    if ((serverup==0)); then
+        if ((as_visual==0)) && ((new_frame==0)); then
+            if (( hasX )); then
+                local rootx=$XTERMGEO_X
+                local rooty=$XTERMGEO_Y
+                if ((nobg)); then
+                    ((xo_verbose)) && set -x # OK if you are grepping
+                    $emacs_exe -g "+${rootx}+${rooty}" \
+                               "${emacs_opts[@]}" "${allfiles[@]}"
+                    ((xo_verbose)) && set +x # OK if you are grepping
+                else
+                    ((xo_verbose)) && set -x # OK if you are grepping
+                    $emacs_exe -g "+${rootx}+${rooty}" \
+                               "${emacs_opts[@]}" "${allfiles[@]}" &
+                    ((xo_verbose)) && set +x # OK if you are grepping
+                fi
             else
                 ((xo_verbose)) && set -x # OK if you are grepping
-                $emacs_exe -g "+${rootx}+${rooty}" \
-                           "${emacs_opts[@]}" "${allfiles[@]}" &
+                $emacs_exe -nw \
+                           "${emacs_opts[@]}" "${allfiles[@]}" < /dev/tty
                 ((xo_verbose)) && set +x # OK if you are grepping
             fi
         else
-            ((xo_verbose)) && set -x # OK if you are grepping
-            $emacs_exe -nw \
-                       "${emacs_opts[@]}" "${allfiles[@]}" < /dev/tty
-            ((xo_verbose)) && set +x # OK if you are grepping
+            xo-ce "No emacs server found. Start one and try again or use -m."
         fi
-    else
-        cmd-echo --id xo "No emacs server found. Start one and try again or use -m."
-    fi
-elif ((serverup==1)); then
-    if ((${#allfiles[@]})); then
-        if ((new_frame)); then
-            if ((nobg)); then
+    elif ((serverup==1)); then
+        local -a command
+        if ((force_x)); then
+            command=(env -u WAYLAND_DISPLAY -u WAYLAND_SOCKET
+                     -u XDG_SESSION_TYPE GDK_BACKEND=x11 DISPLAY="$DISPLAY")
+        fi
+        command+=("$emacsclient_exe")
+        if ((${#allfiles[@]})); then
+            if ((new_frame)); then
+                if ((nobg)); then
+                    ((xo_verbose)) && set -x # OK if you are grepping
+                    "${command[@]}" -c "${emacs_opts[@]}" "${allfiles[@]}" | grep -v 'Waiting for Emacs'
+                    ((xo_verbose)) && set +x # OK if you are grepping
+                else
+                    ((xo_verbose)) && set -x # OK if you are grepping
+                    "${command[@]}" -c "${emacs_opts[@]}" "${allfiles[@]}" | grep -v 'Waiting for Emacs' &
+                    ((xo_verbose)) && set +x # OK if you are grepping
+                fi
+            elif ((as_visual==1)); then
                 ((xo_verbose)) && set -x # OK if you are grepping
-                $emacsclient_exe -c "${emacs_opts[@]}" "${allfiles[@]}" | grep -v 'Waiting for Emacs'
+                "${command[@]}" -c "${emacs_opts[@]}" "${allfiles[@]}"
                 ((xo_verbose)) && set +x # OK if you are grepping
             else
                 ((xo_verbose)) && set -x # OK if you are grepping
-                $emacsclient_exe -c "${emacs_opts[@]}" "${allfiles[@]}" | grep -v 'Waiting for Emacs' &
+                "${command[@]}"  -n -a "$emacs_exe" "${emacs_opts[@]}" "${allfiles[@]}"
                 ((xo_verbose)) && set +x # OK if you are grepping
             fi
-        elif ((as_visual==1)); then
-            ((xo_verbose)) && set -x # OK if you are grepping
-            $emacsclient_exe -c "${emacs_opts[@]}" "${allfiles[@]}"
-            ((xo_verbose)) && set +x # OK if you are grepping
         else
-            ((xo_verbose)) && set -x # OK if you are grepping
-            $emacsclient_exe -n -a "$emacs_exe" "${emacs_opts[@]}" "${allfiles[@]}"
-            ((xo_verbose)) && set +x # OK if you are grepping
+            xo-ce "Server already up. Specify a file to edit."
         fi
-    else
-        cmd-echo --id xo "Server already up. Specify a file to edit."
     fi
-fi
 
-true; exit
+    true;
+}
+
+main "$@";
 
 # shellcheck disable=SC2317 #https://github.com/koalaman/shellcheck/wiki/SC2317
 :<<'__PODUSAGE__'
@@ -289,6 +336,7 @@ xo - Start up emacs, using X and client mode where possible.
      [--exe /path/to/emacs ] \\
      [--org|--todo] [--gim] [--which file[,file...]] \\
      [--norc] [--nf] [--xov] [--fo|files-only] \\
+     [--force-x] \\
      [-- any-emacs-opts] [file [file...]]
 
   xo [--nobg] --geo-only <emacs opts and args>
@@ -416,6 +464,11 @@ Print the emacs command that is run.
 =item --fo|--files-only
 
 Files only. If you do 'xo *', skip the directories.
+
+=item force-x
+
+Don't use Wayland, use X11. Only for running emacs back on a machine from which
+you have 'ssh -Y'-ed into. Wayland does not do -Y.
 
 =item -- any-emacs-opts
 

--- a/dotfiles/completions/post-any-install
+++ b/dotfiles/completions/post-any-install
@@ -7,18 +7,21 @@
 
 _post-any-install_completion()
 {
-    local cur prev word script
+    local cur prev word script value action
     local i
     local expecting_option_argument=0
     local end_of_options=0
-    local positional_count=0
+
+    local -A used_actions=()
+    local -a valid_actions_list=()
+    local -a available_actions=()
 
     local -a options_with_arguments=(
         --os
     )
 
     local -a options_without_arguments=(
-        --molog
+        --nolog
         --no-log
     )
 
@@ -32,7 +35,11 @@ _post-any-install_completion()
     cur=${COMP_WORDS[COMP_CWORD]}
     prev=${COMP_WORDS[COMP_CWORD - 1]}
 
-    # Complete an argument following --os.
+    ##
+    ## --os
+    ##
+
+    # Handle --os value
     if [[ $prev == --os ]]; then
         mapfile -t COMPREPLY < <(
             compgen -W "${os_values[*]}" -- "$cur"
@@ -40,7 +47,7 @@ _post-any-install_completion()
         return
     fi
 
-    # Complete --os=value.
+    # Handle --os=value
     if [[ $cur == --os=* ]]; then
         local value=${cur#--os=}
         local -a values
@@ -57,7 +64,9 @@ _post-any-install_completion()
         return
     fi
 
-    # Examine completed arguments preceding the current word.
+    ##
+    ## Examine completed arguments preceding the current word.
+    ##
     for ((i = 1; i < COMP_CWORD; i++)); do
         word=${COMP_WORDS[i]}
 
@@ -93,12 +102,14 @@ _post-any-install_completion()
                 ;;
 
             *)
-                ((positional_count++))
+                used_actions["$word"]=1
                 ;;
         esac
     done
 
-    # Complete option names.
+    ##
+    ## Complete option names.
+    ##
     if (( ! end_of_options )) && [[ $cur == -* ]]; then
         mapfile -t COMPREPLY < <(
             compgen -W \
@@ -108,6 +119,12 @@ _post-any-install_completion()
         return
     fi
 
+    ##
+    ## Handle action arguments.
+    ##
+
+    # Get current command's file. We are going to pull the argument values from
+    # the file.
     script=$(command -v post-any-install) || {
         COMPREPLY=()
         return
@@ -116,7 +133,6 @@ _post-any-install_completion()
     # Extract names from definitions resembling:
     #
     # pai-something() { #action
-    #
     mapfile -t valid_actions_list < <(
         sed -nE '
             /^pai-[[:alnum:]_-]+[[:space:]]*\(\)[[:space:]]*\{[[:space:]]*#action/ {
@@ -127,8 +143,17 @@ _post-any-install_completion()
         ' "$script"
     )
 
+    # Eliminate actions that have been typed already
+    for action in "${valid_actions_list[@]}"; do
+        [[ -v 'used_actions[$action]' ]] ||
+            available_actions+=("$action")
+    done
+
+    compopt -o nosort # Preserve the incomming order as an indicator of what
+                      # order to specify actions if specifying more than one.
+
     mapfile -t COMPREPLY < <(
-        compgen -W "all ${valid_actions_list[*]}" -- "$cur"
+        compgen -W "all restart ${available_actions[*]}" -- "$cur"
     )
 }
 

--- a/dotfiles/completions/xo
+++ b/dotfiles/completions/xo
@@ -1,0 +1,258 @@
+# -*- sh -*-
+# shellcheck shell=bash
+
+# xo - Tab completion function for xo.
+# Developed with the assistance of ChatGPT running the GPT-5.5 model.
+
+########################################################################
+# Global variables, meant to live between function invocations.
+
+# Persistent in-memory cache for _xo_completion().
+declare -ga _xo_path_cache=()
+declare -g  _xo_path_cache_path=
+declare -g  _xo_path_cache_prefix=
+declare -gi _xo_path_cache_built_at=0
+declare -gi _xo_path_cache_max_age=300 # PATH Cache lifetime in seconds (5 minutes).
+
+_xo_completion()
+{
+    local cur prev opt val
+    local candidate basename encoding result
+    local cache_now cache_age
+    local i
+
+    local attached=0
+    local completing_option=0
+    local rebuild_path_cache=0
+
+    local -a path_dirs=()
+    local -a matches=()
+    local -A cached_paths_seen=()
+
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD - 1]}
+    printf -v cache_now '%(%s)T' -1
+
+    ########################################################################
+    # Completion for the switches themselves, for example:
+    #
+    #     xo -<Tab>
+    #     xo --w<Tab>
+    #
+    # Do not enter this branch for an attached option argument such as
+    # --which=perl.
+    ########################################################################
+
+    case $cur in
+        -S=*|--which=*)
+            # These are attached option arguments for which we can provide
+            # completion. They are handled below. Not all option args have
+            # completion support.
+            ;;
+
+        -*)
+            local options_list=(-x -h
+                                --geo-only --nobg --debug-init --debug --forceX --root --exe
+                                --gim --nf --todo --org --norc --xov --fo --files-only --std --stdin-file
+                                --iso --isolated --force-x --help
+                               )
+            mapfile -t COMPREPLY < <(
+                compgen -W "${options_list[*]}" -- "$cur"
+            )
+            return
+            ;;
+    esac
+
+    ########################################################################
+    # Determine whether an attached or separate option argument is being
+    # completed.
+    #
+    # Supported forms:
+    #
+    #     -S command
+    #     --which command
+    #     -S=command
+    #     --which=command
+    ########################################################################
+
+    case $cur in
+        -S=*|--which=*)
+            opt=${cur%%=*}
+            val=${cur#*=}
+            attached=1
+            completing_option=1
+            ;;
+    esac
+
+    if (( ! completing_option )); then
+        case $prev in
+            -S|--which)
+                opt=$prev
+                val=$cur
+                completing_option=1
+                ;;
+        esac
+    fi
+
+    ########################################################################
+    # Fall back to ordinary filename completion when this is not the
+    # argument to -S or --which.
+    ########################################################################
+
+    if (( ! completing_option )); then
+        mapfile -t COMPREPLY < <(
+            compgen -f -- "$cur"
+        )
+
+        compopt -o filenames
+        return
+    fi
+
+    ########################################################################
+    # Complete explicit pathname arguments directly.
+    #
+    # Once the option value contains a slash, it is no longer a command-name
+    # search through PATH. Retain only executable text files.
+    ########################################################################
+
+    if [[ $val == */* ]]; then
+        mapfile -t matches < <(
+            compgen -f -- "$val"
+        )
+
+        COMPREPLY=()
+
+        for candidate in "${matches[@]}"; do
+            [[ -f $candidate && -x $candidate ]] ||
+                continue
+
+            encoding=$(
+                file -Lb --mime-encoding -- "$candidate" 2>/dev/null
+            ) || continue
+
+            [[ $encoding != binary ]] ||
+                continue
+
+            if (( attached )); then
+                COMPREPLY+=("$opt=$candidate")
+            else
+                COMPREPLY+=("$candidate")
+            fi
+        done
+
+        return
+    fi
+
+    ########################################################################
+    # Decide whether the in-memory PATH cache must be rebuilt.
+    #
+    # Rebuild when:
+    #
+    #   1. The cache has never been built.
+    #   2. PATH has changed.
+    #   3. The cache has aged out.
+    #   4. The current value does not begin with the cached prefix.
+    #
+    # Examples:
+    #
+    #   Cached prefix "par", current value "part":
+    #       Reuse the cache and filter it for "part".
+    #
+    #   Cached prefix "par", current value "pag":
+    #       Rebuild the cache for "pag".
+    #
+    #   Cached prefix "par", current value "pa":
+    #       Rebuild because the broader search may have additional matches.
+    ########################################################################
+
+    if ((_xo_path_cache_built_at == 0)); then
+        rebuild_path_cache=1
+    elif [[ $_xo_path_cache_path != "$PATH" ]]; then
+        rebuild_path_cache=1
+    else
+        cache_age=$((cache_now - _xo_path_cache_built_at))
+
+        if ((cache_age >= _xo_path_cache_max_age)); then
+            rebuild_path_cache=1
+        elif [[ $val != "$_xo_path_cache_prefix"* ]]; then
+            rebuild_path_cache=1
+        fi
+    fi
+
+    ########################################################################
+    # Rebuild the in-memory PATH cache.
+    #
+    # The cache contains full paths to executable text files whose basenames
+    # begin with the current option value.
+    ########################################################################
+
+    if (( rebuild_path_cache )); then
+        IFS=: read -ra path_dirs <<< "$PATH"
+
+        # An empty PATH component represents the current directory.
+        for i in "${!path_dirs[@]}"; do
+            [[ -n ${path_dirs[i]} ]] ||
+                path_dirs[i]=.
+        done
+
+        _xo_path_cache=()
+        cached_paths_seen=()
+
+        while IFS= read -r -d '' candidate; do
+            # Avoid duplicates caused by repeated PATH directories.
+            [[ -v 'cached_paths_seen[$candidate]' ]] &&
+                continue
+
+            encoding=$(
+                file -Lb --mime-encoding -- "$candidate" 2>/dev/null
+            ) || continue
+
+            # file(1) reports "binary" for binary executables and other
+            # non-text data. Retain ASCII, UTF-8, and other text encodings.
+            [[ $encoding != binary ]] ||
+                continue
+
+            cached_paths_seen["$candidate"]=1
+            _xo_path_cache+=("$candidate")
+        done < <(
+            find "${path_dirs[@]}" \
+                -maxdepth 1 \
+                -xtype f \
+                -executable \
+                -name "${val}*" \
+                -print0 \
+                2>/dev/null
+        )
+
+        _xo_path_cache_path=$PATH
+        _xo_path_cache_prefix=$val
+        _xo_path_cache_built_at=$cache_now
+    fi
+
+    ########################################################################
+    # Filter the cached results against the current value and construct
+    # COMPREPLY.
+    #
+    # Filtering is necessary when the current value is more specific than
+    # the prefix used to build the cache.
+    ########################################################################
+
+    COMPREPLY=()
+
+    for candidate in "${_xo_path_cache[@]}"; do
+        basename=${candidate##*/}
+
+        [[ $basename == "$val"* ]] ||
+            continue
+
+        if (( attached )); then
+            result="$opt=$candidate"
+        else
+            result=$candidate
+        fi
+
+        COMPREPLY+=("$result")
+    done
+}
+
+complete -F _xo_completion xo

--- a/dotfiles/dotfiles.manifest
+++ b/dotfiles/dotfiles.manifest
@@ -27,7 +27,8 @@ dotfiles[inputrc]=${HOME}/.inputrc
 dotfiles[perltidyrc]=${HOME}/.perltidyrc
 dotfiles[perlchecklibs]=${HOME}/.perlcheck.libs
 dotfiles[perl_module_starter]=${HOME}/.module-starter/config
-dotfiles['post-any-install']=${HOME}/.local/share/bash-completion/completions/post-any-install
+dotfiles['completions/xo']=${HOME}/.local/share/bash-completion/completions/xo
+dotfiles['completions/post-any-install']=${HOME}/.local/share/bash-completion/completions/post-any-install
 
 ## Not all machines get these.
 ## Key is name of file in dotfiles dir.


### PR DESCRIPTION
bin/build-oss
* Defined a BUILD_OSS_ROOT to help organize things.
* Allow for the removal of standard build-oss-* functions from the config file if the step is not needed to build a particular software.
* Revamped. Using a timestamp file to avoid unnecessary builds. Updated the generated config. Put the guts in a main() function. Removed the ability to restart-with-logger after generating the config as it was too complicated and not needed.
* Don't need to export any variables.
* declare => local swap.

bin/cmd-pause
* Added support for -l (show the line number) in cmd-echo.

bin/git-pre-commit-hook
* Add --source-path=SCRIPTDIR to shellcheck call to help avoid errors when variables are defined in sourced files.

bin/inflect
* Converted from Lingua::EN::Inflect to Lingua::EN::Inflexion.

bin/perl.mopenv
* Replace /opt/mop with $OPTROOT.

bin/post-any-install
* Error message typo.
* Swap apt X => apt-get X to eliminate the annoying WARNING.
* Swap declare => local in functions.
* Added restart capability.

pai-debian-distro-packages():
  * No longer installing 'suggests' packages. Way too many dependencies for some packages.

bin/post-any-install.data
* Added Lingua::EN::Inflexion, Lingua::EN::Inflect. Pulled Term::Readline::Perl, compilation failed, required terminal input, not used..
* Whacked with extreme prejudice pacakge devscripts from debian package list. Over 1000 dependencies, including some that use a TUI that screws up terminals.

pai-patch-dispatch():
  * Takes over for the pai-patch files that were local to the build directories of the patched code. That way we do not have a file on one machine that could be git clean-ed away.

bin/webperldoc
* perlsoc to a browser.

bin/xo
* Added --force-x when trying to run remotely, as Wayland won't work with ssh -Y.
* Added -S as alias for --which.
* Converted to using getopt, local instead of declare inside functions, and a main() function.
* Why were we lowercaseing options?

dotfiles/completions/post-any-install
* Added restart action.

dotfiles/completions/xo
* Bash completion file for xo.

dotfiles/dotfiles.manifest
* Added bash cli completion files xo and post-any-install.

dotfiles/post-any-install
* Do not sort completions for 'action', keeping required running order for multiple 'action's.
* Make multiple 'action's unique.